### PR TITLE
Fix: Running containers missing from UI due to JSON Network gateway omission

### DIFF
--- a/Orchard/Models.swift
+++ b/Orchard/Models.swift
@@ -133,16 +133,31 @@ struct UserID: Codable, Equatable {
 }
 
 struct Network: Codable, Equatable {
-    let gateway: String
-    let hostname: String
-    let network: String
-    let address: String
+    var gateway: String
+    var hostname: String
+    var network: String
+    var address: String
 
     enum CodingKeys: String, CodingKey {
         case gateway
         case hostname
         case network
         case address
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        gateway = try container.decodeIfPresent(String.self, forKey: .gateway) ?? ""
+        hostname = try container.decodeIfPresent(String.self, forKey: .hostname) ?? ""
+        network = try container.decodeIfPresent(String.self, forKey: .network) ?? ""
+        address = try container.decodeIfPresent(String.self, forKey: .address) ?? ""
+    }
+    
+    init(gateway: String = "", hostname: String = "", network: String = "", address: String = "") {
+        self.gateway = gateway
+        self.hostname = hostname
+        self.network = network
+        self.address = address
     }
 }
 

--- a/Orchard/Views/Features/Containers/EditContainer.swift
+++ b/Orchard/Views/Features/Containers/EditContainer.swift
@@ -502,7 +502,7 @@ struct EditContainerView: View {
                 workingDirectory: "/app",
                 arguments: ["nginx", "-g", "daemon off;"],
                 executable: "/usr/sbin/nginx",
-                user: User(id: nil, raw: nil),
+                user: User(id: UserID(gid: 0, uid: 0), raw: UserRaw(userString: "root")),
                 rlimits: [],
                 supplementalGroups: []
             ),


### PR DESCRIPTION
Hi 👋 @andrew-waters 

Thanks for creating and maintaining Orchard! I really enjoy using it and wanted to contribute a small fix for a bug where running containers sometimes don't show up in the UI list.

**Problem:**
When a container is in a `Running` state, the `container ls --format json` API sometimes completely omits the `gateway` key within the `networks` payload. Because the `Network` struct in `Models.swift` has strict non-optional decodable requirements for `gateway`, the native `JSONDecoder` silently throws a `valueNotFound` error. This results in the UI dropping running containers from the list entirely because the JSON deserialization fails.

**Solution:**
I added a standard Swift `init(from decoder:)` block to the `Network` model. This allows the decoder to gracefully fall back to an empty string `""` (or other default values) if any network keys are missing, without needing to break the public property type signatures or introduce optional unwrapping across the rest of the UI views.

Tested locally against the missing `gateway` keys, and all running containers are showing up perfectly again! Let me know if you need any adjustments to the code!
