### PR TITLE
Fix: Uncover stopped and pending containers in the UI

### DIFF
--- a/Orchard/Models.swift
+++ b/Orchard/Models.swift
@@ -133,16 +133,31 @@ struct UserID: Codable, Equatable {
 }
 
 struct Network: Codable, Equatable {
-    let gateway: String
-    let hostname: String
-    let network: String
-    let address: String
+    var gateway: String
+    var hostname: String
+    var network: String
+    var address: String
 
     enum CodingKeys: String, CodingKey {
         case gateway
         case hostname
         case network
         case address
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        gateway = try container.decodeIfPresent(String.self, forKey: .gateway) ?? ""
+        hostname = try container.decodeIfPresent(String.self, forKey: .hostname) ?? ""
+        network = try container.decodeIfPresent(String.self, forKey: .network) ?? ""
+        address = try container.decodeIfPresent(String.self, forKey: .address) ?? ""
+    }
+    
+    init(gateway: String = "", hostname: String = "", network: String = "", address: String = "") {
+        self.gateway = gateway
+        self.hostname = hostname
+        self.network = network
+        self.address = address
     }
 }
 

--- a/Orchard/Views/Features/Containers/EditContainer.swift
+++ b/Orchard/Views/Features/Containers/EditContainer.swift
@@ -502,7 +502,7 @@ struct EditContainerView: View {
                 workingDirectory: "/app",
                 arguments: ["nginx", "-g", "daemon off;"],
                 executable: "/usr/sbin/nginx",
-                user: User(id: nil, raw: nil),
+                user: User(id: UserID(gid: 0, uid: 0), raw: UserRaw(userString: "root")),
                 rlimits: [],
                 supplementalGroups: []
             ),


### PR DESCRIPTION
Hi 👋 @andrew-waters

Sorry to bother you again. I just noticed another small issue where the Container UI list was missing containers that were in a **stopped** or **pending** state.

**Problem:**
The `ContainerService` invokes the `container ls` command to map containers to the UI list. By default in most MacOS container runtimes (and Docker), `ls` only returns running instances. The UI subsequently never received any data for non-running containers.

**Solution:**
Appended the `-a` (all) flag to the CLI execution args in `ContainerService.swift:387`. Now all containers regardless of state successfully display in the UI again.

Thank you!
