### PR TITLE
Fix: Uncover stopped and pending containers in the UI

### DIFF
--- a/Orchard/Services/ContainerService.swift
+++ b/Orchard/Services/ContainerService.swift
@@ -383,7 +383,7 @@ class ContainerService: ObservableObject {
         do {
             result = try exec(
                 program: safeContainerBinaryPath(),
-                arguments: ["ls", "--format", "json"])
+                arguments: ["ls", "-a", "--format", "json"])
         } catch {
             let error = error as! ExecError
             result = error.execResult


### PR DESCRIPTION
Hi 👋 @andrew-waters

Sorry to bother you again. I just noticed another small issue where the Container UI list was missing containers that were in a **stopped** or **pending** state.

**Problem:**
The `ContainerService` invokes the `container ls` command to map containers to the UI list. By default in most MacOS container runtimes (and Docker), `ls` only returns running instances. The UI subsequently never received any data for non-running containers.

**Solution:**
Appended the `-a` (all) flag to the CLI execution args in `ContainerService.swift:387`. Now all containers regardless of state successfully display in the UI again.

_(Note: Re-opening this PR from the correct branch.)_

Thank you!
