### PR TITLE
Respect detached mode setting when running containers

### DIFF
--- a/Orchard/Services/ContainerService.swift
+++ b/Orchard/Services/ContainerService.swift
@@ -2092,7 +2092,8 @@ class ContainerService: ObservableObject {
         publishedPorts: [PublishPort],
         dns: ContainerResource.ContainerConfiguration.DNSConfiguration?,
         networkName: String,
-        autoRemove: Bool
+        autoRemove: Bool,
+        terminal: Bool
     ) async throws {
         // Fetch or pull the image
         let image = try await ClientImage.fetch(reference: imageRef)
@@ -2144,7 +2145,7 @@ class ContainerService: ObservableObject {
             arguments: Array(processArgs.dropFirst()),
             environment: mergedEnv,
             workingDirectory: wd,
-            terminal: false,
+            terminal: terminal,
             user: user
         )
 
@@ -2246,7 +2247,8 @@ class ContainerService: ObservableObject {
                 publishedPorts: ports,
                 dns: dns,
                 networkName: config.network,
-                autoRemove: config.removeAfterStop
+                autoRemove: config.removeAfterStop,
+                terminal: !config.detached
             )
 
             await MainActor.run {
@@ -2255,6 +2257,10 @@ class ContainerService: ObservableObject {
 
                 Task {
                     await loadContainers()
+                }
+
+                if !config.detached {
+                    self.openTerminal(for: id)
                 }
             }
         } catch {

--- a/Orchard/Views/Features/Containers/EditContainer.swift
+++ b/Orchard/Views/Features/Containers/EditContainer.swift
@@ -54,7 +54,7 @@ struct EditContainerView: View {
         _config = State(initialValue: ContainerRunConfig(
             name: container.configuration.id,
             image: container.configuration.image.reference,
-            detached: true,
+            detached: !container.configuration.initProcess.terminal,
             removeAfterStop: false,
             environmentVariables: envVars,
             portMappings: [], // Port mappings not available in container config


### PR DESCRIPTION
- Modified `ContainerService.createAndStartContainer` to accept and use a `terminal` flag.
- Updated `ContainerService.runContainer` to set the `terminal` flag based on the `detached` setting.
- In `runContainer`, automatically open a terminal session when starting a container in foreground (non-detached) mode.
- Fixed `EditContainer.swift` to correctly initialize the detached toggle from the container's existing terminal configuration.

Fixes andrew-waters#43

[Untested code as of yet, so marking as draft PR]