### PR TITLE
Fix issue where Edit Configuration loses Executable path

### DIFF
--- a/Orchard/Models.swift
+++ b/Orchard/Models.swift
@@ -599,6 +599,7 @@ struct ContainerRunConfig: Equatable {
     var volumeMappings: [VolumeMapping] = []
     var workingDirectory: String = ""
     var commandOverride: String = ""
+    var executable: String = ""
     var dnsDomain: String = ""
     var network: String = ""
 

--- a/Orchard/Services/ContainerService.swift
+++ b/Orchard/Services/ContainerService.swift
@@ -2066,7 +2066,11 @@ class ContainerService: ObservableObject {
             environmentVariables: envVars,
             portMappings: portMappings,
             volumeMappings: volumeMappings,
-            dnsDomain: config.dns.domain ?? ""
+            workingDirectory: config.initProcess.workingDirectory,
+            commandOverride: config.initProcess.arguments.joined(separator: " "),
+            executable: config.initProcess.executable,
+            dnsDomain: config.dns.domain ?? "",
+            network: snapshot.networks.first?.network ?? ""
         )
 
         await runContainer(config: runConfig)
@@ -2088,6 +2092,7 @@ class ContainerService: ObservableObject {
         environment: [String],
         workingDirectory: String,
         commandOverride: [String],
+        executableOverride: String? = nil,
         mounts: [Filesystem],
         publishedPorts: [PublishPort],
         dns: ContainerResource.ContainerConfiguration.DNSConfiguration?,
@@ -2139,9 +2144,20 @@ class ContainerService: ObservableObject {
 
         let wd = workingDirectory.isEmpty ? (imageConfig?.workingDir ?? "/") : workingDirectory
 
+        let executable: String
+        let arguments: [String]
+
+        if let override = executableOverride, !override.isEmpty {
+            executable = override
+            arguments = processArgs
+        } else {
+            executable = processArgs.first!
+            arguments = Array(processArgs.dropFirst())
+        }
+
         let process = ProcessConfiguration(
-            executable: processArgs.first!,
-            arguments: Array(processArgs.dropFirst()),
+            executable: executable,
+            arguments: arguments,
             environment: mergedEnv,
             workingDirectory: wd,
             terminal: false,
@@ -2242,6 +2258,7 @@ class ContainerService: ObservableObject {
                 environment: envStrings,
                 workingDirectory: config.workingDirectory,
                 commandOverride: commandArgs,
+                executableOverride: config.executable,
                 mounts: mounts,
                 publishedPorts: ports,
                 dns: dns,

--- a/Orchard/Views/Features/Containers/EditContainer.swift
+++ b/Orchard/Views/Features/Containers/EditContainer.swift
@@ -60,7 +60,10 @@ struct EditContainerView: View {
             portMappings: [], // Port mappings not available in container config
             volumeMappings: volumes,
             workingDirectory: container.configuration.initProcess.workingDirectory,
-            commandOverride: container.configuration.initProcess.arguments.joined(separator: " ")
+            commandOverride: container.configuration.initProcess.arguments.joined(separator: " "),
+            executable: container.configuration.initProcess.executable,
+            dnsDomain: container.configuration.dns.domain ?? "",
+            network: container.networks.first?.network ?? ""
         ))
     }
 
@@ -93,6 +96,10 @@ struct EditContainerView: View {
             footerView
         }
         .frame(width: 700, height: 650)
+        .task {
+            await containerService.loadNetworks()
+            await containerService.loadDNSDomains()
+        }
     }
 
     private var headerView: some View {
@@ -206,6 +213,43 @@ struct EditContainerView: View {
                 Text("Container name cannot be changed")
                     .font(.caption)
                     .foregroundColor(.secondary)
+            }
+
+            VStack(alignment: .leading, spacing: 8) {
+                Text("DNS Domain")
+                    .font(.subheadline)
+                    .fontWeight(.medium)
+
+                Picker("DNS Domain", selection: $config.dnsDomain) {
+                    Text("None").tag("")
+                    ForEach(containerService.dnsDomains, id: \.domain) { domain in
+                        Text(domain.domain).tag(domain.domain)
+                    }
+                }
+                .pickerStyle(.menu)
+                .frame(width: 200, alignment: .leading)
+
+                if !config.dnsDomain.isEmpty {
+                    Text("Selected: \(config.dnsDomain)")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                        .padding(.top, 2)
+                }
+            }
+
+            VStack(alignment: .leading, spacing: 8) {
+                Text("Network")
+                    .font(.subheadline)
+                    .fontWeight(.medium)
+
+                Picker("Network", selection: $config.network) {
+                    Text("Default").tag("")
+                    ForEach(containerService.networks, id: \.id) { network in
+                        Text(network.id).tag(network.id)
+                    }
+                }
+                .pickerStyle(.menu)
+                .frame(width: 200, alignment: .leading)
             }
 
             VStack(alignment: .leading, spacing: 8) {
@@ -347,6 +391,19 @@ struct EditContainerView: View {
                     .textFieldStyle(.roundedBorder)
 
                 Text("Override the default working directory inside the container")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+            }
+
+            VStack(alignment: .leading, spacing: 8) {
+                Text("Executable")
+                    .font(.subheadline)
+                    .fontWeight(.medium)
+
+                TextField("/path/to/executable", text: $config.executable)
+                    .textFieldStyle(.roundedBorder)
+
+                Text("Override the default executable")
                     .font(.caption)
                     .foregroundColor(.secondary)
             }

--- a/Orchard/Views/Features/Containers/RunContainer.swift
+++ b/Orchard/Views/Features/Containers/RunContainer.swift
@@ -367,6 +367,19 @@ struct RunContainerView: View {
             }
 
             VStack(alignment: .leading, spacing: 8) {
+                Text("Executable")
+                    .font(.subheadline)
+                    .fontWeight(.medium)
+
+                TextField("/path/to/executable", text: $config.executable)
+                    .textFieldStyle(.roundedBorder)
+
+                Text("Override the default executable")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+            }
+
+            VStack(alignment: .leading, spacing: 8) {
                 Text("Command Override")
                     .font(.subheadline)
                     .fontWeight(.medium)


### PR DESCRIPTION
- Added `executable` field to `ContainerRunConfig` model.
- Updated `ContainerService.createAndStartContainer` to support explicit executable override.
- Improved container recovery and edit flow by populating Executable, DNS Domain, and Network from existing configuration.
- Added UI fields for Executable, DNS Domain, and Network in `EditContainerView`.
- Added UI field for Executable in `RunContainerView`.
- Fixed command argument processing logic when an executable override is provided.

[ Haven't tested the code, so marking as Draft PR]