### PR TITLE
fix: ensure tab controls are clickable across entire area

### DIFF
--- a/Orchard/Views/Features/Containers/EditContainer.swift
+++ b/Orchard/Views/Features/Containers/EditContainer.swift
@@ -170,6 +170,7 @@ struct EditContainerView: View {
             .background(selectedTab == tab ? Color.accentColor.opacity(0.2) : Color.clear)
             .foregroundColor(selectedTab == tab ? .accentColor : .secondary)
             .cornerRadius(6)
+            .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
     }

--- a/Orchard/Views/Features/Containers/RunContainer.swift
+++ b/Orchard/Views/Features/Containers/RunContainer.swift
@@ -140,6 +140,7 @@ struct RunContainerView: View {
             .background(selectedTab == tab ? Color.accentColor.opacity(0.2) : Color.clear)
             .foregroundColor(selectedTab == tab ? .accentColor : .secondary)
             .cornerRadius(6)
+            .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
     }

--- a/Orchard/Views/Layout/Sidebar/SidebarTabs.swift
+++ b/Orchard/Views/Layout/Sidebar/SidebarTabs.swift
@@ -80,6 +80,7 @@ struct SidebarTabs: View {
                                 isActiveTab ? Color.accentColor.opacity(isWindowFocused ? 0.15 : 0.08) : Color.clear
                             )
                             .cornerRadius(6)
+                            .contentShape(Rectangle())
                     }
                     .buttonStyle(.plain)
                     .help(tab.title)


### PR DESCRIPTION
Added `.contentShape(Rectangle())` to custom tab buttons in EditContainer, RunContainer, and SidebarTabs to ensure they respond to clicks even in transparent areas. This matches the behavior already implemented in ContainerDetail and follows standard SwiftUI hit-testing practices for plain button styles.

Enhanced fix https://github.com/andrew-waters/orchard/issues/36