### PR TITLE
fix: system properties stuck on Loading... due to wrong JSON format

### DIFF
--- a/Orchard/Services/ContainerService.swift
+++ b/Orchard/Services/ContainerService.swift
@@ -1,6 +1,7 @@
 import Foundation
 import SwiftUI
 import AppKit
+import UniformTypeIdentifiers
 import ContainerAPIClient
 import ContainerResource
 import ContainerizationOCI
@@ -83,6 +84,7 @@ class ContainerService: ObservableObject {
     @Published var isSystemPropertiesLoading = false
     @Published var preferredTerminal: TerminalApp = .terminal
     @Published var installedTerminals: [TerminalApp] = [.terminal]
+    @Published var systemDefaultTerminal: (bundleID: String, displayName: String)?
 
     // Container operation locks to prevent multiple simultaneous operations
     private var containerOperationLocks: Set<String> = []
@@ -170,13 +172,34 @@ class ContainerService: ObservableObject {
 
     private func loadPreferredTerminal() {
         installedTerminals = TerminalApp.installedTerminals
+        detectSystemDefaultTerminal()
+
         let userDefaults = UserDefaults.standard
         if let savedTerminal = userDefaults.string(forKey: preferredTerminalKey),
            let terminal = TerminalApp(rawValue: savedTerminal),
            terminal.isInstalled {
             preferredTerminal = terminal
+        } else if let systemDefault = systemDefaultTerminal,
+                  let matched = TerminalApp(rawValue: systemDefault.bundleID),
+                  matched.isInstalled {
+            preferredTerminal = matched
         } else if let firstInstalled = installedTerminals.first {
             preferredTerminal = firstInstalled
+        }
+    }
+
+    private func detectSystemDefaultTerminal() {
+        let contentTypes: [UTType] = [.unixExecutable, .shellScript]
+        for type in contentTypes {
+            guard let appURL = NSWorkspace.shared.urlForApplication(toOpen: type) else { continue }
+            let bundle = Bundle(url: appURL)
+            guard let bundleID = bundle?.bundleIdentifier, !bundleID.isEmpty else { continue }
+            let appName = appURL.deletingPathExtension().lastPathComponent
+            let displayName = bundle?.localizedInfoDictionary?["CFBundleDisplayName"] as? String
+                ?? bundle?.infoDictionary?["CFBundleDisplayName"] as? String
+                ?? appName
+            systemDefaultTerminal = (bundleID: bundleID, displayName: displayName)
+            return
         }
     }
 
@@ -1561,51 +1584,56 @@ class ContainerService: ObservableObject {
     }
 
     private func parseSystemPropertiesFromOutput(_ output: String) -> [SystemProperty] {
+        guard let data = output.data(using: .utf8),
+              let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            return []
+        }
+
         var properties: [SystemProperty] = []
 
-        do {
-            guard let data = output.data(using: .utf8) else {
-                return properties
-            }
+        let idMappings: [String: String] = [
+            "build.image": "image.builder",
+            "vminit.image": "image.init",
+        ]
 
-            if let jsonArray = try JSONSerialization.jsonObject(with: data) as? [[String: Any]] {
-                for propertyDict in jsonArray {
-                    guard let id = propertyDict["id"] as? String,
-                          let typeString = propertyDict["type"] as? String,
-                          let description = propertyDict["description"] as? String else {
-                        continue
-                    }
-
-                    // Handle value which can be null, bool, or string
+        func flatten(_ dict: [String: Any], prefix: String = "") {
+            for (key, value) in dict {
+                let dotKey = prefix.isEmpty ? key : "\(prefix).\(key)"
+                if let nestedDict = value as? [String: Any] {
+                    flatten(nestedDict, prefix: dotKey)
+                } else {
+                    let propertyId = idMappings[dotKey] ?? dotKey
                     let valueString: String
-                    if let value = propertyDict["value"] {
-                        if value is NSNull {
-                            valueString = "*undefined*"
-                        } else if let boolValue = value as? Bool {
-                            valueString = boolValue ? "true" : "false"
-                        } else if let stringValue = value as? String {
-                            valueString = stringValue
-                        } else {
-                            valueString = String(describing: value)
-                        }
-                    } else {
-                        valueString = "*undefined*"
-                    }
+                    let type: SystemProperty.PropertyType
 
-                    let type: SystemProperty.PropertyType = typeString.lowercased() == "bool" ? .bool : .string
+                    if value is NSNull {
+                        valueString = "*undefined*"
+                        type = .string
+                    } else if let boolValue = value as? Bool {
+                        valueString = boolValue ? "true" : "false"
+                        type = .bool
+                    } else if let stringValue = value as? String {
+                        valueString = stringValue
+                        type = .string
+                    } else if let numberValue = value as? NSNumber {
+                        valueString = numberValue.stringValue
+                        type = .string
+                    } else {
+                        valueString = String(describing: value)
+                        type = .string
+                    }
 
                     properties.append(SystemProperty(
-                        id: id,
+                        id: propertyId,
                         type: type,
                         value: valueString,
-                        description: description
+                        description: ""
                     ))
                 }
             }
-        } catch {
-            print("Error parsing system properties JSON: \(error)")
         }
 
+        flatten(json)
         return properties
     }
 

--- a/Orchard/Services/ContainerService.swift
+++ b/Orchard/Services/ContainerService.swift
@@ -1,7 +1,6 @@
 import Foundation
 import SwiftUI
 import AppKit
-import UniformTypeIdentifiers
 import ContainerAPIClient
 import ContainerResource
 import ContainerizationOCI
@@ -84,8 +83,6 @@ class ContainerService: ObservableObject {
     @Published var isSystemPropertiesLoading = false
     @Published var preferredTerminal: TerminalApp = .terminal
     @Published var installedTerminals: [TerminalApp] = [.terminal]
-    @Published var systemDefaultTerminal: (bundleID: String, displayName: String)?
-
     // Container operation locks to prevent multiple simultaneous operations
     private var containerOperationLocks: Set<String> = []
     private let lockQueue = DispatchQueue(label: "containerOperationLocks", attributes: .concurrent)
@@ -172,34 +169,14 @@ class ContainerService: ObservableObject {
 
     private func loadPreferredTerminal() {
         installedTerminals = TerminalApp.installedTerminals
-        detectSystemDefaultTerminal()
 
         let userDefaults = UserDefaults.standard
         if let savedTerminal = userDefaults.string(forKey: preferredTerminalKey),
            let terminal = TerminalApp(rawValue: savedTerminal),
            terminal.isInstalled {
             preferredTerminal = terminal
-        } else if let systemDefault = systemDefaultTerminal,
-                  let matched = TerminalApp(rawValue: systemDefault.bundleID),
-                  matched.isInstalled {
-            preferredTerminal = matched
         } else if let firstInstalled = installedTerminals.first {
             preferredTerminal = firstInstalled
-        }
-    }
-
-    private func detectSystemDefaultTerminal() {
-        let contentTypes: [UTType] = [.unixExecutable, .shellScript]
-        for type in contentTypes {
-            guard let appURL = NSWorkspace.shared.urlForApplication(toOpen: type) else { continue }
-            let bundle = Bundle(url: appURL)
-            guard let bundleID = bundle?.bundleIdentifier, !bundleID.isEmpty else { continue }
-            let appName = appURL.deletingPathExtension().lastPathComponent
-            let displayName = bundle?.localizedInfoDictionary?["CFBundleDisplayName"] as? String
-                ?? bundle?.infoDictionary?["CFBundleDisplayName"] as? String
-                ?? appName
-            systemDefaultTerminal = (bundleID: bundleID, displayName: displayName)
-            return
         }
     }
 

--- a/Orchard/Views/Features/Configuration/ConfigurationDetail.swift
+++ b/Orchard/Views/Features/Configuration/ConfigurationDetail.swift
@@ -31,6 +31,16 @@ struct ConfigurationDetailView: View {
                         Text("The terminal application to use when opening a shell into a container.")
                             .foregroundColor(.secondary)
                             .padding(.leading, 10)
+
+                        if let systemDefault = containerService.systemDefaultTerminal {
+                            let label = containerService.preferredTerminal.bundleIdentifier == systemDefault.bundleID
+                                ? "System default (\(systemDefault.displayName))"
+                                : "macOS default: \(systemDefault.displayName)"
+                            Text(label)
+                                .foregroundColor(.secondary)
+                                .font(.caption)
+                                .padding(.leading, 10)
+                        }
                     }
 
                     Spacer()
@@ -264,6 +274,7 @@ struct ConfigurationDetailView: View {
         .onAppear {
             Task {
                 await containerService.loadSystemProperties()
+                await containerService.loadDNSDomains()
             }
         }
     }

--- a/Orchard/Views/Features/Configuration/ConfigurationDetail.swift
+++ b/Orchard/Views/Features/Configuration/ConfigurationDetail.swift
@@ -32,15 +32,6 @@ struct ConfigurationDetailView: View {
                             .foregroundColor(.secondary)
                             .padding(.leading, 10)
 
-                        if let systemDefault = containerService.systemDefaultTerminal {
-                            let label = containerService.preferredTerminal.bundleIdentifier == systemDefault.bundleID
-                                ? "System default (\(systemDefault.displayName))"
-                                : "macOS default: \(systemDefault.displayName)"
-                            Text(label)
-                                .foregroundColor(.secondary)
-                                .font(.caption)
-                                .padding(.leading, 10)
-                        }
                     }
 
                     Spacer()


### PR DESCRIPTION
`container system property list --format=json` returns a nested dictionary (the full ContainerSystemConfig), but the parser expected a flat array of `{id, type, value, description}` objects. The cast silently failed, leaving systemProperties always empty.

Rewrite parseSystemPropertiesFromOutput to recursively flatten the nested dict using dot-separated keys, with idMappings for properties where the JSON path differs from Orchard's expected ID (build.image → image.builder, vminit.image → image.init).

Also add loadDNSDomains() to ConfigurationDetail's onAppear so the DNS Domain picker loads when the view appears.