### PR TITLE
Fix Pages appcast no-op and add real release notes

### DIFF
--- a/.github/scripts/changelog_to_html.py
+++ b/.github/scripts/changelog_to_html.py
@@ -1,15 +1,38 @@
 #!/usr/bin/env python3
-"""Emit the CHANGELOG section for a version as minimal HTML for Sparkle release notes.
+"""Emit the CHANGELOG section for a version for release notes.
 
-Usage: changelog_to_html.py <version> [changelog_path]
+Usage: changelog_to_html.py [--markdown] <version> [changelog_path]
 
-Prints the HTML for the `## [<version>]` section (headings, bullet lists, links,
-bold, inline code) to stdout. Prints nothing and exits 0 if the section is absent,
-so the release workflow can fall back to a plain link.
+Default: prints the HTML for the `## [<version>]` section (headings, bullet lists,
+links, bold, inline code) — used inline in the Sparkle appcast.
+With --markdown: prints the section body verbatim as markdown (heading line excluded)
+— used as the GitHub release body. Either way, prints nothing and exits 0 if the
+section is absent, so callers can fall back to a plain link.
 """
+from __future__ import annotations
+
 import sys
 import re
 import html
+
+
+def extract_section(version: str, path: str) -> list[str] | None:
+    """Return the lines of the `## [<version>]` section body, or None if absent.
+
+    Excludes the version heading itself and stops at the next `## ` header.
+    """
+    lines = open(path, encoding="utf-8").read().splitlines()
+    target = re.compile(r"^## \[" + re.escape(version) + r"\]")
+    start = next((i + 1 for i, ln in enumerate(lines) if target.match(ln)), None)
+    if start is None:
+        return None
+
+    section = []
+    for ln in lines[start:]:
+        if ln.startswith("## "):  # next version header
+            break
+        section.append(ln)
+    return section
 
 
 def inline(text: str) -> str:
@@ -22,22 +45,24 @@ def inline(text: str) -> str:
 
 
 def main() -> None:
-    if len(sys.argv) < 2:
+    args = sys.argv[1:]
+    markdown = False
+    if args and args[0] == "--markdown":
+        markdown = True
+        args = args[1:]
+    if not args:
         return
-    version = sys.argv[1]
-    path = sys.argv[2] if len(sys.argv) > 2 else "CHANGELOG.md"
+    version = args[0]
+    path = args[1] if len(args) > 1 else "CHANGELOG.md"
 
-    lines = open(path, encoding="utf-8").read().splitlines()
-    target = re.compile(r"^## \[" + re.escape(version) + r"\]")
-    start = next((i + 1 for i, ln in enumerate(lines) if target.match(ln)), None)
-    if start is None:
+    section = extract_section(version, path)
+    if section is None:
         return  # no section → caller falls back
 
-    section = []
-    for ln in lines[start:]:
-        if ln.startswith("## "):  # next version header
-            break
-        section.append(ln)
+    if markdown:
+        # Emit the section body verbatim, trimmed of leading/trailing blank lines.
+        print("\n".join(section).strip())
+        return
 
     out: list[str] = []
     in_list = False

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -87,22 +87,93 @@ jobs:
         uses: actions/configure-pages@v5
 
       - name: Upload artifact
+        id: upload
         uses: actions/upload-pages-artifact@v3
         with:
           path: _site
 
-      # Retry once: GitHub's Pages deployment API intermittently returns
-      # "Deployment failed, try again later" for a single attempt. A retry after a short
-      # pause clears the vast majority of those transient failures.
+      # We call the Pages deployments REST API directly instead of using
+      # actions/deploy-pages@v4, because that action hardcodes pages_build_version to
+      # GITHUB_SHA (its src/internal/context.js). GitHub Pages treats a deployment whose
+      # build version equals the currently-live one as a no-op: it reports success but
+      # never swaps the served content. Our release flow always collides — the "Bump
+      # version" commit's ci.yml run deploys that SHA first, then release.yml deploys the
+      # *same* SHA (carrying the fresh appcast) minutes later and silently no-ops. Nothing
+      # can override GITHUB_SHA via `env:` (the runner ignores writes to GITHUB_*), so we
+      # pass our own per-run-unique build version here. Retries once, matching the
+      # transient-failure handling this step used to have — and now fails loudly on an
+      # unrecoverable error rather than silently serving stale content.
       - name: Deploy to GitHub Pages
         id: deploy
-        uses: actions/deploy-pages@v4
-        continue-on-error: true
+        uses: actions/github-script@v7
+        env:
+          ARTIFACT_ID: ${{ steps.upload.outputs.artifact_id }}
+          # Unique per workflow run (and per "re-run failed jobs" attempt), so no two
+          # deployments ever share a build version — this is what stops the release
+          # deploy from no-opping over ci's earlier one.
+          BUILD_VERSION: ${{ github.sha }}-${{ github.run_id }}-${{ github.run_attempt }}
+        with:
+          script: |
+            const artifactId = Number(process.env.ARTIFACT_ID);
+            const buildVersion = process.env.BUILD_VERSION;
+            const { owner, repo } = context.repo;
+            const TERMINAL_FAILURES = [
+              'deployment_failed',
+              'deployment_content_failed',
+              'deployment_cancelled',
+              'deployment_lost',
+            ];
 
-      - name: Wait before retry
-        if: steps.deploy.outcome == 'failure'
-        run: sleep 20
+            async function deployOnce() {
+              const idToken = await core.getIDToken();
+              const created = await github.request('POST /repos/{owner}/{repo}/pages/deployments', {
+                owner,
+                repo,
+                artifact_id: artifactId,
+                pages_build_version: buildVersion,
+                oidc_token: idToken,
+              });
+              const deploymentId =
+                created.data.id || created.data.status_url?.split('/').pop() || buildVersion;
+              core.info(`Created deployment ${deploymentId} (build version ${buildVersion})`);
+              if (created.data.page_url) {
+                core.setOutput('page_url', created.data.page_url);
+              }
 
-      - name: Deploy to GitHub Pages (retry)
-        if: steps.deploy.outcome == 'failure'
-        uses: actions/deploy-pages@v4
+              // Poll until the deployment reaches a terminal state (10 min ceiling).
+              // Tolerate a few consecutive transient status-query errors before giving
+              // up (as deploy-pages does) — one flaky GET shouldn't abandon an otherwise
+              // healthy deployment.
+              let consecutiveErrors = 0;
+              for (let i = 0; i < 120; i++) {
+                await new Promise(r => setTimeout(r, 5000));
+                let data;
+                try {
+                  ({ data } = await github.request(
+                    'GET /repos/{owner}/{repo}/pages/deployments/{deploymentId}',
+                    { owner, repo, deploymentId }
+                  ));
+                  consecutiveErrors = 0;
+                } catch (error) {
+                  if (++consecutiveErrors > 10) throw error;
+                  core.warning(`Status query failed (${error.message}); ${consecutiveErrors} in a row, still polling…`);
+                  continue;
+                }
+                core.info(`Deployment status: ${data.status}`);
+                if (data.status === 'succeed') return;
+                if (TERMINAL_FAILURES.includes(data.status)) {
+                  throw new Error(`Deployment reached terminal failure state: ${data.status}`);
+                }
+              }
+              throw new Error('Timed out waiting for the Pages deployment to succeed');
+            }
+
+            // Retry once: the Pages deployment API intermittently returns a transient
+            // failure that clears on a second attempt after a short pause.
+            try {
+              await deployOnce();
+            } catch (error) {
+              core.warning(`Deploy attempt failed (${error.message}); retrying once in 20s…`);
+              await new Promise(r => setTimeout(r, 20000));
+              await deployOnce();
+            }

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -124,7 +124,7 @@ jobs:
               'deployment_lost',
             ];
 
-            async function deployOnce() {
+            async function createDeployment() {
               const idToken = await core.getIDToken();
               const created = await github.request('POST /repos/{owner}/{repo}/pages/deployments', {
                 owner,
@@ -139,7 +139,10 @@ jobs:
               if (created.data.page_url) {
                 core.setOutput('page_url', created.data.page_url);
               }
+              return deploymentId;
+            }
 
+            async function pollUntilDone(deploymentId) {
               // Poll until the deployment reaches a terminal state (10 min ceiling).
               // Tolerate a few consecutive transient status-query errors before giving
               // up (as deploy-pages does) — one flaky GET shouldn't abandon an otherwise
@@ -168,12 +171,17 @@ jobs:
               throw new Error('Timed out waiting for the Pages deployment to succeed');
             }
 
-            // Retry once: the Pages deployment API intermittently returns a transient
-            // failure that clears on a second attempt after a short pause.
+            // Retry only the *create*: the Pages API intermittently returns a transient
+            // "try again later" at creation, which clears on a second attempt. We never
+            // re-POST after a deployment exists — that would duplicate an in-flight
+            // deploy or re-use its build version — so once created we only poll, and a
+            // poll-phase failure surfaces honestly rather than being masked by a retry.
+            let deploymentId;
             try {
-              await deployOnce();
+              deploymentId = await createDeployment();
             } catch (error) {
-              core.warning(`Deploy attempt failed (${error.message}); retrying once in 20s…`);
+              core.warning(`Create failed (${error.message}); retrying once in 20s…`);
               await new Promise(r => setTimeout(r, 20000));
-              await deployOnce();
+              deploymentId = await createDeployment();
             }
+            await pollUntilDone(deploymentId);

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -292,6 +292,39 @@ jobs:
             Orchard-${{ steps.version.outputs.version }}.dmg
             Orchard-${{ steps.version.outputs.version }}.dmg.sha256
 
+      # Assemble the release body, using this version's CHANGELOG section as the "Changes"
+      # section. Falls back to the generic line if the section is missing.
+      - name: Build release notes
+        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          NOTES=$(python3 .github/scripts/changelog_to_html.py --markdown "$VERSION" CHANGELOG.md || true)
+          if [[ -z "$NOTES" ]]; then
+            NOTES="See the commit history for detailed changes in this release."
+          fi
+
+          {
+            echo "## Orchard v${VERSION}"
+            echo
+            echo "### Installation"
+            echo "1. Download the DMG file below"
+            echo "2. Open the DMG and drag Orchard.app to your Applications folder"
+            echo "3. Launch Orchard from Applications"
+            echo
+            echo "### Changes"
+            printf '%s\n' "$NOTES"
+            echo
+            echo "### Checksums"
+            echo "- **SHA256**: See the \`.sha256\` file for verification"
+            echo
+            echo "### System Requirements"
+            echo "- macOS 26 (Tahoe)"
+            echo "- [Apple Container](https://github.com/apple/container) installed"
+          } > release-notes.md
+
+          echo "Assembled release notes:"; cat release-notes.md
+
       - name: Create Release
         if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
         uses: softprops/action-gh-release@v1
@@ -299,23 +332,7 @@ jobs:
           files: |
             Orchard-${{ steps.version.outputs.version }}.dmg
             Orchard-${{ steps.version.outputs.version }}.dmg.sha256
-          body: |
-            ## Orchard v${{ steps.version.outputs.version }}
-
-            ### Installation
-            1. Download the DMG file below
-            2. Open the DMG and drag Orchard.app to your Applications folder
-            3. Launch Orchard from Applications
-
-            ### Changes
-            See the commit history for detailed changes in this release.
-
-            ### Checksums
-            - **SHA256**: See the `.sha256` file for verification
-
-            ### System Requirements
-            - macOS 26 (Tahoe)
-            - [Apple Container](https://github.com/apple/container) installed
+          body_path: release-notes.md
           draft: false
           prerelease: false
         env:


### PR DESCRIPTION
## Why

Two release-pipeline problems, one branch.

### 1. The appcast never goes live
`https://orchard.andon.dev/appcast.xml` was stuck at 1.12.6 even though the v1.12.7 release ran end-to-end and gh-pages already holds the correct 1.12.7 appcast — the second release in a row this happened.

**Root cause:** `actions/deploy-pages@v4` hardcodes `pages_build_version` to `GITHUB_SHA` (its `src/internal/context.js`), and GitHub Pages treats a deployment whose build version equals the currently-live one as a **no-op** — it reports success but never swaps the served content ([actions/deploy-pages#383](https://github.com/actions/deploy-pages/issues/383)). Our flow always collides on SHA: the "Bump version" commit triggers `ci.yml`, whose deploy lands first (~6 min) with the stale appcast; the tag on that *same commit* triggers `release.yml`, whose deploy lands ~11 min later with the **identical SHA** carrying the fresh appcast → silent no-op. Manual `workflow_dispatch` re-deploys of the live SHA no-op too, so uniqueness — not a structural single-owner change — is the robust fix.

`GITHUB_SHA` **cannot** be overridden via `env:` (the runner ignores writes to `GITHUB_*`), so a step-level override is a dead end.

**Fix:** `pages.yml` now calls the Pages deployments REST API directly (via `github-script`) with a per-run-unique `pages_build_version` (`${{ github.sha }}-${{ github.run_id }}-${{ github.run_attempt }}`), replicating deploy-pages' OIDC + create + status-poll (same terminal-state set, same 10-min ceiling) and its retry-once behaviour, plus transient-poll-error tolerance. On an unrecoverable error it now **fails loudly** instead of silently serving stale content. Everything else in `pages.yml` is unchanged (concurrency group, appcast artifact handoff, gh-pages fallback, coverage-badge overlay).

### 2. Real release notes
Release bodies hardcoded "See the commit history for detailed changes in this release." They now use the version's `CHANGELOG.md` section: `changelog_to_html.py` gains a `--markdown` mode (reusing a shared `extract_section` with the existing HTML/appcast mode), and `release.yml` assembles the body from it, falling back to the generic line when a section is missing. Installation / Checksums / System Requirements are preserved verbatim.

## Self-heal for v1.12.7 (no retag)
gh-pages already has the correct 1.12.7 appcast. Merging this PR creates a new commit on `main` → ci's deploy of that new SHA publishes the 1.12.7 appcast via the gh-pages fallback. No retag/rebuild needed.

## Verification
- Extractor tested locally in both modes across several versions incl. 1.12.7; HTML output byte-identical to before.
- Embedded deploy script node-syntax-checked; both workflows YAML-validated.
- After merge + Pages deploy: `curl -s https://orchard.andon.dev/appcast.xml | grep shortVersionString` → 1.12.7.
- Existing published releases will be backfilled with their CHANGELOG notes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)