### PR TITLE
Fix Pages deploy 404 and keep release deploys unique

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -14,6 +14,17 @@ on:
       - "site/**"
       - ".github/workflows/pages.yml"
   workflow_call:
+    inputs:
+      build_version:
+        description: >-
+          Commit SHA to publish as the Pages build version. Must be a real
+          commit SHA — the Pages API 404s on anything else. Callers pass a
+          distinct real SHA (e.g. release.yml's gh-pages appcast commit) so a
+          same-source-commit redeploy isn't treated as a no-op. Defaults to the
+          triggering commit when omitted.
+        type: string
+        required: false
+        default: ""
   workflow_dispatch:
 
 permissions:
@@ -96,22 +107,22 @@ jobs:
       # actions/deploy-pages@v4, because that action hardcodes pages_build_version to
       # GITHUB_SHA (its src/internal/context.js). GitHub Pages treats a deployment whose
       # build version equals the currently-live one as a no-op: it reports success but
-      # never swaps the served content. Our release flow always collides — the "Bump
-      # version" commit's ci.yml run deploys that SHA first, then release.yml deploys the
-      # *same* SHA (carrying the fresh appcast) minutes later and silently no-ops. Nothing
-      # can override GITHUB_SHA via `env:` (the runner ignores writes to GITHUB_*), so we
-      # pass our own per-run-unique build version here. Retries once, matching the
-      # transient-failure handling this step used to have — and now fails loudly on an
-      # unrecoverable error rather than silently serving stale content.
+      # never swaps the served content. Our release flow collides — the "Bump version"
+      # commit's ci.yml run deploys that SHA first, then release.yml deploys the *same*
+      # SHA (carrying the fresh appcast) minutes later and would silently no-op. So callers
+      # can override the build version via the build_version input.
+      #
+      # The build version MUST be a real commit SHA: despite the REST docs calling it "a
+      # unique string", the backend 404s on anything else (actions/deploy-pages#383).
+      # release.yml passes its fresh gh-pages appcast commit SHA — distinct from ci's
+      # main-branch SHA — so both deploys take effect. Every other path defaults to the
+      # triggering commit, exactly what deploy-pages sent before.
       - name: Deploy to GitHub Pages
         id: deploy
         uses: actions/github-script@v7
         env:
           ARTIFACT_ID: ${{ steps.upload.outputs.artifact_id }}
-          # Unique per workflow run (and per "re-run failed jobs" attempt), so no two
-          # deployments ever share a build version — this is what stops the release
-          # deploy from no-opping over ci's earlier one.
-          BUILD_VERSION: ${{ github.sha }}-${{ github.run_id }}-${{ github.run_attempt }}
+          BUILD_VERSION: ${{ inputs.build_version || github.sha }}
         with:
           script: |
             const artifactId = Number(process.env.ARTIFACT_ID);

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,6 +50,12 @@ jobs:
   build:
     needs: test
     runs-on: macos-15
+    # gh-pages HEAD after the appcast push — handed to the Pages deploy as its build
+    # version. It's a fresh orphan-branch commit, so it's always distinct from ci.yml's
+    # main-branch deploy of the same release commit, which is what stops the release
+    # deploy from no-opping over ci's earlier one (see pages.yml).
+    outputs:
+      ghpages_sha: ${{ steps.ghpages_sha.outputs.sha }}
 
     steps:
       - uses: actions/checkout@v4
@@ -349,6 +355,17 @@ jobs:
           publish_dir: ./_site
           keep_files: true
 
+      # Capture the commit the appcast push just created on gh-pages. The Pages deploy
+      # uses it as the build version so this release's deploy differs from ci.yml's
+      # earlier deploy of the same release commit and actually serves the fresh appcast.
+      - name: Capture gh-pages commit for the Pages deploy
+        id: ghpages_sha
+        if: steps.appcast.outputs.generated == 'true'
+        run: |
+          SHA=$(git ls-remote "${{ github.server_url }}/${{ github.repository }}" refs/heads/gh-pages | cut -f1)
+          echo "sha=$SHA" >> "$GITHUB_OUTPUT"
+          echo "gh-pages HEAD: $SHA"
+
   # Publish the site (with the freshly-persisted appcast) via GitHub Actions Pages.
   deploy-pages:
     needs: build
@@ -357,3 +374,7 @@ jobs:
       pages: write
       id-token: write
     uses: ./.github/workflows/pages.yml
+    # Empty when no appcast was generated (e.g. workflow_dispatch without a tag); pages.yml
+    # then falls back to github.sha.
+    with:
+      build_version: ${{ needs.build.outputs.ghpages_sha }}


### PR DESCRIPTION
## Problem

Every `Deploy site to GitHub Pages` run on `main` fails with `404 Not Found` from `POST /repos/{owner}/{repo}/pages/deployments`.

The deploy step (added in #62) passed a fabricated `pages_build_version` of `<sha>-<run_id>-<attempt>` to force uniqueness and stop release deploys from no-opping. But the Pages deployments API **requires a real commit SHA** and returns `404` for anything else — the REST docs calling it "a unique string" is misleading (confirmed by [actions/deploy-pages#383](https://github.com/actions/deploy-pages/issues/383)). So the fabricated value 404s deterministically; re-running never helps.

This left both designs as dead ends:
- bare `GITHUB_SHA` → deploys, but a release re-deploys the same commit ci already deployed and **no-ops** (stale appcast — the original bug #62 was fixing)
- `sha-run_id-attempt` → **404**, every time

## Fix

- **`pages.yml`** — default `BUILD_VERSION` to `github.sha` (a real SHA, exactly what `actions/deploy-pages` sent before), and add an optional `build_version` workflow_call input so callers can override it.
- **`release.yml`** — after the appcast is persisted to `gh-pages`, capture that fresh commit's SHA and pass it as `build_version`. It's an orphan-branch commit, always distinct from ci's main-branch deploy of the same release commit, so the release deploy takes effect instead of no-opping.
- **`ci.yml`** — unchanged; falls back to `github.sha`.

## Result

- 404 gone — every path sends a real commit SHA.
- Release stale-appcast no-op gone — ci deploys the main SHA, release deploys the distinct gh-pages SHA; both take effect.
- Site-only pushes still deploy (new main SHA each push).

## Verification

Both workflow files validated as YAML. CI workflow logic only runs on GitHub, so the live proof is the first push to `main` after merge (the `github.sha` path is byte-identical to the previously-working `deploy-pages` behavior). The release `gh-pages`-SHA path is first exercised on the next tagged release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)