### PR TITLE
Support Apple container 1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- Updated for Apple's `container` 1.1.0. Orchard now builds against the 1.1.0 client libraries (previously 0.12.3), which had many breaking API changes across the 1.0 release; container 1.0.0 or later is now required.
+
+### Fixed
+- Stop, force-stop, and remove container actions work again on container 1.0.0 and later. Orchard was still linking the pre-1.0 client, so these commands silently failed against a 1.x daemon and the container never stopped ([#54](https://github.com/andrew-waters/orchard/issues/54)).
+
 ## [1.12.7] - 2026-07-05
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Stop, force-stop, and remove container actions work again on container 1.0.0 and later. Orchard was still linking the pre-1.0 client, so these commands silently failed against a 1.x daemon and the container never stopped ([#54](https://github.com/andrew-waters/orchard/issues/54)).
+- The System pane in Settings no longer stays stuck on "Loading…". container 1.0 changed `system property list --format=json` from a flat array to a nested object keyed by category, which the parser didn't recognise, so every daemon property read as missing.
 
 ## [1.12.7] - 2026-07-05
 

--- a/Orchard.xcodeproj/project.pbxproj
+++ b/Orchard.xcodeproj/project.pbxproj
@@ -619,7 +619,7 @@
 			repositoryURL = "https://github.com/apple/container.git";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 0.12.3;
+				minimumVersion = 1.1.0;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/Orchard.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Orchard.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -15,8 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/container.git",
       "state" : {
-        "revision" : "f9899013fd43dd058fdf89709eed0b0861bfd931",
-        "version" : "0.12.3"
+        "revision" : "5973b9cc626a3e7a499bb316a958237ebe14e2ed",
+        "version" : "1.1.0"
       }
     },
     {
@@ -24,8 +24,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/containerization.git",
       "state" : {
-        "revision" : "f1ee6f8b737ab8dffbd620bfa47283f6f0bc1822",
-        "version" : "0.31.0"
+        "revision" : "44bec8b9933bc491d0cbf44abac90a1f6aaebf6b",
+        "version" : "0.35.0"
       }
     },
     {
@@ -137,6 +137,15 @@
       }
     },
     {
+      "identity" : "swift-configuration-toml",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/mattt/swift-configuration-toml",
+      "state" : {
+        "revision" : "4ea16b4dfa4b023cecae5ae0368402c4d846d613",
+        "version" : "2.0.0"
+      }
+    },
+    {
       "identity" : "swift-crypto",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-crypto.git",
@@ -179,6 +188,15 @@
       "state" : {
         "revision" : "8c0f217f01000dd30f60d6e536569ad4e74291f9",
         "version" : "1.11.0"
+      }
+    },
+    {
+      "identity" : "swift-metrics",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-metrics",
+      "state" : {
+        "revision" : "087e8074afa97040c3b870c8664fe5482fb87cc4",
+        "version" : "2.11.0"
       }
     },
     {

--- a/Orchard/Services/CLIParsers.swift
+++ b/Orchard/Services/CLIParsers.swift
@@ -58,49 +58,90 @@ func parseDNSDomains(json output: String, defaultDomain: String?) -> [DNSDomain]
 
 // MARK: - System properties
 
-/// Parses `container system property list --format=json`, which emits a JSON array of
-/// `{id, type, value, description}` objects. `type` is "Bool" or "String"; `value` is a
-/// JSON bool, string, number, or null (null → the `*undefined*` sentinel).
+/// Legacy id aliases, mapping the daemon's category keys to the ids the app looks up.
+private let systemPropertyIDAliases: [String: String] = [
+    "build.image": "image.builder",
+    "vminit.image": "image.init",
+]
+
+/// Parses `container system property list --format=json`. As of container 1.0 the daemon
+/// emits a nested object keyed by category (`{"build": {"rosetta": true, …}, …}`); pre-1.0
+/// daemons emitted a flat array of `{id, type, value, description}`. Both are handled.
 func parseSystemProperties(json output: String) -> [SystemProperty] {
     guard let data = output.data(using: .utf8),
-          let array = try? JSONSerialization.jsonObject(with: data) as? [[String: Any]] else {
+          let root = try? JSONSerialization.jsonObject(with: data) else {
         return []
     }
 
-    // Legacy id aliases, kept in case older daemons emit the pre-rename ids.
-    let idMappings: [String: String] = [
-        "build.image": "image.builder",
-        "vminit.image": "image.init",
-    ]
-
-    return array.compactMap { entry in
-        guard let rawId = entry["id"] as? String else { return nil }
-        let propertyId = idMappings[rawId] ?? rawId
-
-        let type = (entry["type"] as? String)
-            .flatMap(SystemProperty.PropertyType.init(rawValue:)) ?? .string
-
-        let rawValue = entry["value"]
-        let valueString: String
-        if rawValue == nil || rawValue is NSNull {
-            valueString = "*undefined*"
-        } else if type == .bool, let boolValue = rawValue as? Bool {
-            valueString = boolValue ? "true" : "false"
-        } else if let stringValue = rawValue as? String {
-            valueString = stringValue
-        } else if let numberValue = rawValue as? NSNumber {
-            valueString = numberValue.stringValue
-        } else {
-            valueString = String(describing: rawValue!)
+    // container 1.0+: nested `{category: {key: value}}` object. Checked before the array
+    // form because a JSON array does not cast to a dictionary.
+    if let categories = root as? [String: Any] {
+        return categories.flatMap { category, value -> [SystemProperty] in
+            guard let fields = value as? [String: Any] else { return [] }
+            return fields.map { key, raw in
+                let rawId = "\(category).\(key)"
+                let (type, valueString) = normalizeSystemPropertyValue(raw)
+                return SystemProperty(
+                    id: systemPropertyIDAliases[rawId] ?? rawId,
+                    type: type,
+                    value: valueString,
+                    description: ""
+                )
+            }
         }
-
-        return SystemProperty(
-            id: propertyId,
-            type: type,
-            value: valueString,
-            description: entry["description"] as? String ?? ""
-        )
     }
+
+    // Pre-1.0: flat array of `{id, type, value, description}` objects.
+    if let array = root as? [[String: Any]] {
+        return array.compactMap { entry in
+            guard let rawId = entry["id"] as? String else { return nil }
+            let type = (entry["type"] as? String)
+                .flatMap(SystemProperty.PropertyType.init(rawValue:)) ?? .string
+
+            let rawValue = entry["value"]
+            let valueString: String
+            if rawValue == nil || rawValue is NSNull {
+                valueString = "*undefined*"
+            } else if type == .bool, let boolValue = rawValue as? Bool {
+                valueString = boolValue ? "true" : "false"
+            } else if let stringValue = rawValue as? String {
+                valueString = stringValue
+            } else if let numberValue = rawValue as? NSNumber {
+                valueString = numberValue.stringValue
+            } else {
+                valueString = String(describing: rawValue!)
+            }
+
+            return SystemProperty(
+                id: systemPropertyIDAliases[rawId] ?? rawId,
+                type: type,
+                value: valueString,
+                description: entry["description"] as? String ?? ""
+            )
+        }
+    }
+
+    return []
+}
+
+/// Classifies a raw JSON scalar from the nested property object as a bool or string and
+/// renders it to the app's string form. JSON booleans bridge to `NSNumber` (`CFBoolean`),
+/// so they are distinguished from numbers by CoreFoundation type rather than `as? Bool`,
+/// which also matches 0/1 integers.
+private func normalizeSystemPropertyValue(_ raw: Any) -> (SystemProperty.PropertyType, String) {
+    if raw is NSNull {
+        return (.string, "*undefined*")
+    }
+    if let string = raw as? String {
+        return (.string, string)
+    }
+    if let number = raw as? NSNumber {
+        if CFGetTypeID(number) == CFBooleanGetTypeID() {
+            return (.bool, number.boolValue ? "true" : "false")
+        }
+        return (.string, number.stringValue)
+    }
+    return (.string, String(describing: raw))
 }
 
 // MARK: - Docker Hub search

--- a/Orchard/Services/ContainerBackend.swift
+++ b/Orchard/Services/ContainerBackend.swift
@@ -75,7 +75,7 @@ protocol ContainerBackend: Sendable {
     func deleteImage(reference: String) async throws
     func inspectImage(reference: String) async throws -> ImageInspection
     func listNetworks() async throws -> [ContainerNetwork]
-    func createNetwork(name: String, labels: [String: String]) async throws
+    func createNetwork(name: String, subnet: String?, labels: [String: String]) async throws
     func deleteNetwork(id: String) async throws
     func ping() async throws -> SystemHealthInfo
     func diskUsage() async throws -> SystemDiskUsage
@@ -275,10 +275,12 @@ struct LiveContainerBackend: ContainerBackend {
         return resources.map { mapNetworkResource($0) }
     }
 
-    func createNetwork(name: String, labels: [String: String]) async throws {
+    func createNetwork(name: String, subnet: String?, labels: [String: String]) async throws {
+        let ipv4Subnet = try subnet.flatMap { $0.isEmpty ? nil : try CIDRv4($0) }
         let config = try NetworkConfiguration(
             name: name,
             mode: .nat,
+            ipv4Subnet: ipv4Subnet,
             labels: try ResourceLabels(labels),
             plugin: "container-network-vmnet"
         )

--- a/Orchard/Services/ContainerBackend.swift
+++ b/Orchard/Services/ContainerBackend.swift
@@ -3,6 +3,7 @@ import ContainerAPIClient
 import ContainerResource
 import ContainerizationOCI
 import ContainerizationExtras
+import ContainerPersistence
 
 // MARK: - Boundary value types
 
@@ -85,6 +86,13 @@ protocol ContainerBackend: Sendable {
 /// `ContainerBackend` backed by the real XPC client, translating client model types to
 /// and from the app's domain models.
 struct LiveContainerBackend: ContainerBackend {
+    /// The persisted system configuration (registry, DNS, scheme, …) that image
+    /// operations require as of container 1.1.0. Loaded from the same TOML layers the
+    /// `container` CLI reads, so pulls resolve identically to the command line.
+    private func loadContainerSystemConfig() async throws -> ContainerSystemConfig {
+        try await ConfigurationLoader.load()
+    }
+
     func listContainers() async throws -> [Container] {
         let snapshots = try await ContainerClient().list()
         return snapshots.map { mapContainer($0) }
@@ -95,7 +103,9 @@ struct LiveContainerBackend: ContainerBackend {
     }
 
     func killContainer(id: String, signal: Int32) async throws {
-        try await ContainerClient().kill(id: id, signal: signal)
+        // As of container 1.1.0 the client takes the signal as a name/number string;
+        // Signal(_:) on the server parses the numeric form.
+        try await ContainerClient().kill(id: id, signal: String(signal))
     }
 
     func deleteContainer(id: String, force: Bool) async throws {
@@ -133,7 +143,7 @@ struct LiveContainerBackend: ContainerBackend {
         var ports: [PublishPort] = []
         for pm in spec.publishedPorts {
             let proto = PublishProtocol(pm.transportProtocol) ?? .tcp
-            ports.append(PublishPort(
+            ports.append(try PublishPort(
                 hostAddress: try IPAddress("0.0.0.0"),
                 hostPort: pm.hostPort,
                 containerPort: pm.containerPort,
@@ -153,7 +163,8 @@ struct LiveContainerBackend: ContainerBackend {
         }()
 
         // Fetch/unpack the image and read its OCI config.
-        let image = try await ClientImage.fetch(reference: spec.imageRef)
+        let systemConfig = try await loadContainerSystemConfig()
+        let image = try await ClientImage.fetch(reference: spec.imageRef, containerSystemConfig: systemConfig)
         let platform = ContainerizationOCI.Platform.current
         try await image.getCreateSnapshot(platform: platform)
         let kernel = try await ClientKernel.getDefaultKernel(for: .current)
@@ -217,7 +228,7 @@ struct LiveContainerBackend: ContainerBackend {
     }
 
     func pullImage(reference: String) async throws {
-        _ = try await ClientImage.pull(reference: reference)
+        _ = try await ClientImage.pull(reference: reference, containerSystemConfig: try await loadContainerSystemConfig())
     }
 
     func deleteImage(reference: String) async throws {
@@ -225,15 +236,20 @@ struct LiveContainerBackend: ContainerBackend {
     }
 
     func inspectImage(reference: String) async throws -> ImageInspection {
-        let image = try await ClientImage.get(reference: reference)
-        let detail = try await image.details()
+        // container 1.1.0 removed ClientImage.details(); rebuild the inspection from the
+        // OCI index (per-platform manifests) and each platform's config blob.
+        let image = try await ClientImage.get(reference: reference, containerSystemConfig: try await loadContainerSystemConfig())
+        let index = try await image.index()
 
         var variants: [ImageInspection.Variant] = []
-        for v in detail.variants {
-            let config = v.config.config
+        for manifest in index.manifests {
+            guard let platform = manifest.platform else { continue }
+            // Config blobs for non-local architectures may be absent; skip config
+            // details rather than failing the whole inspection.
+            let config = (try? await image.config(for: platform))?.config
             variants.append(ImageInspection.Variant(
-                platform: "\(v.platform.os)/\(v.platform.architecture)",
-                size: v.size,
+                platform: "\(platform.os)/\(platform.architecture)",
+                size: manifest.size,
                 entrypoint: config?.entrypoint,
                 cmd: config?.cmd,
                 env: config?.env,
@@ -244,26 +260,27 @@ struct LiveContainerBackend: ContainerBackend {
             ))
         }
 
+        let descriptor = image.descriptor
         return ImageInspection(
-            name: detail.name,
-            digest: "\(detail.index.digest)",
-            mediaType: detail.index.mediaType,
-            size: detail.index.size,
+            name: image.reference,
+            digest: "\(descriptor.digest)",
+            mediaType: descriptor.mediaType,
+            size: descriptor.size,
             variants: variants
         )
     }
 
     func listNetworks() async throws -> [ContainerNetwork] {
-        let states = try await NetworkClient().list()
-        return states.map { mapNetworkState($0) }
+        let resources = try await NetworkClient().list()
+        return resources.map { mapNetworkResource($0) }
     }
 
     func createNetwork(name: String, labels: [String: String]) async throws {
         let config = try NetworkConfiguration(
-            id: name,
+            name: name,
             mode: .nat,
             labels: try ResourceLabels(labels),
-            pluginInfo: NetworkPluginInfo(plugin: "container-network-vmnet")
+            plugin: "container-network-vmnet"
         )
         _ = try await NetworkClient().create(configuration: config)
     }

--- a/Orchard/Services/ModelMapping.swift
+++ b/Orchard/Services/ModelMapping.swift
@@ -29,7 +29,7 @@ func mapContainerConfiguration(_ config: ContainerResource.ContainerConfiguratio
         resources: mapResources(config.resources),
         labels: config.labels,
         publishedPorts: config.publishedPorts.map { mapPublishPort($0) },
-        publishedSockets: config.publishedSockets.map { $0.containerPath.path },
+        publishedSockets: config.publishedSockets.map { $0.containerPath.string },
         ssh: config.ssh,
         virtualization: config.virtualization,
         sysctls: config.sysctls
@@ -197,26 +197,20 @@ func mapResourceUsage(_ usage: ResourceUsage) -> DiskUsageSection {
     )
 }
 
-// MARK: - Network state mapping
+// MARK: - Network resource mapping
 
-func mapNetworkState(_ state: NetworkState) -> ContainerNetwork {
-    switch state {
-    case .created(let config):
-        return ContainerNetwork(
-            id: config.id,
-            state: "created",
-            config: NetworkConfig(labels: config.labels.dictionary, id: config.id),
-            status: Orchard.NetworkStatus(gateway: nil, address: nil)
+// As of container 1.1.0 the network API replaced the created/running `NetworkState`
+// enum with a single `NetworkResource` that splits persistent `configuration` from
+// runtime `status`. A resource returned by `list()` always carries an assigned
+// status, so it is reported as running.
+func mapNetworkResource(_ resource: NetworkResource) -> ContainerNetwork {
+    ContainerNetwork(
+        id: resource.id,
+        state: "running",
+        config: NetworkConfig(labels: resource.labels.dictionary, id: resource.id),
+        status: Orchard.NetworkStatus(
+            gateway: "\(resource.status.ipv4Gateway)",
+            address: "\(resource.status.ipv4Subnet)"
         )
-    case .running(let config, let status):
-        return ContainerNetwork(
-            id: config.id,
-            state: "running",
-            config: NetworkConfig(labels: config.labels.dictionary, id: config.id),
-            status: Orchard.NetworkStatus(
-                gateway: "\(status.ipv4Gateway)",
-                address: "\(status.ipv4Subnet)"
-            )
-        )
-    }
+    )
 }

--- a/Orchard/Services/NetworkService.swift
+++ b/Orchard/Services/NetworkService.swift
@@ -47,7 +47,7 @@ final class NetworkService: ObservableObject {
                 }
             }
 
-            try await backend.createNetwork(name: name, labels: labelDict)
+            try await backend.createNetwork(name: name, subnet: subnet, labels: labelDict)
             await load()
             return true
         } catch {

--- a/Orchard/Services/UITestSupport.swift
+++ b/Orchard/Services/UITestSupport.swift
@@ -95,7 +95,7 @@ struct UITestBackend: ContainerBackend {
                           config: NetworkConfig(labels: [:], id: UITestSeed.networkID),
                           status: NetworkStatus(gateway: "192.168.64.1", address: "192.168.64.0/24"))]
     }
-    func createNetwork(name: String, labels: [String: String]) async throws {}
+    func createNetwork(name: String, subnet: String?, labels: [String: String]) async throws {}
     func deleteNetwork(id: String) async throws {}
     func ping() async throws -> SystemHealthInfo { SystemHealthInfo(apiServerVersion: "1.0.0") }
     func diskUsage() async throws -> SystemDiskUsage {

--- a/OrchardTests/CLIParserTests.swift
+++ b/OrchardTests/CLIParserTests.swift
@@ -94,10 +94,44 @@ func systemPropertiesParsed() {
     #expect(prop("image.builder")?.value == "ghcr.io/example/builder:latest")
 }
 
-@Test("System properties: malformed / non-array JSON yields an empty list, not a crash")
+@Test("System properties: decodes the container 1.0+ nested-object format")
+func systemPropertiesNestedObject() {
+    // Shape matches `container system property list --format=json` on container 1.0+:
+    // a nested object keyed by category, with no per-property type/description.
+    let json = """
+    {
+      "build": { "cpus": 2, "image": "ghcr.io/example/builder:0.12.0", "rosetta": true },
+      "dns": {},
+      "kernel": { "binaryPath": "opt/kata/vmlinux", "url": "https://example.com/kernel.tar" },
+      "registry": { "domain": "docker.io" },
+      "vminit": { "image": "ghcr.io/example/vminit:0.35.0" }
+    }
+    """
+    let props = parseSystemProperties(json: json)
+    func prop(_ id: String) -> SystemProperty? { props.first { $0.id == id } }
+
+    // JSON booleans are typed .bool (and not confused with numbers).
+    #expect(prop("build.rosetta")?.type == .bool)
+    #expect(prop("build.rosetta")?.value == "true")
+    // Numbers render as strings, typed .string.
+    #expect(prop("build.cpus")?.type == .string)
+    #expect(prop("build.cpus")?.value == "2")
+    // Category keys flatten to dotted ids the panes look up.
+    #expect(prop("kernel.binaryPath")?.value == "opt/kata/vmlinux")
+    #expect(prop("registry.domain")?.value == "docker.io")
+    // Legacy category keys remap to the ids the app expects.
+    #expect(prop("image.builder")?.value == "ghcr.io/example/builder:0.12.0")
+    #expect(prop("image.init")?.value == "ghcr.io/example/vminit:0.35.0")
+    #expect(prop("build.image") == nil)
+    // An empty category contributes nothing.
+    #expect(prop("dns.domain") == nil)
+}
+
+@Test("System properties: malformed / empty JSON yields an empty list, not a crash")
 func systemPropertiesMalformed() {
     #expect(parseSystemProperties(json: "not json").isEmpty)
     #expect(parseSystemProperties(json: "{}").isEmpty)
+    #expect(parseSystemProperties(json: "[]").isEmpty)
 }
 
 @Test("System properties: skips entries without an id and remaps legacy aliases")

--- a/OrchardTests/Mocks.swift
+++ b/OrchardTests/Mocks.swift
@@ -69,7 +69,7 @@ final class MockContainerBackend: ContainerBackend, @unchecked Sendable {
 
     private var _pulledReferences: [String] = []
     private var _deletedImageReferences: [String] = []
-    private var _createdNetworks: [(name: String, labels: [String: String])] = []
+    private var _createdNetworks: [(name: String, subnet: String?, labels: [String: String])] = []
     private var _deletedNetworkIds: [String] = []
     private var _createdSpecs: [ContainerCreateSpec] = []
     private var _deletedContainers: [(id: String, force: Bool)] = []
@@ -151,7 +151,7 @@ final class MockContainerBackend: ContainerBackend, @unchecked Sendable {
     // Recorded calls — read by tests.
     var pulledReferences: [String] { lock.withLock { _pulledReferences } }
     var deletedImageReferences: [String] { lock.withLock { _deletedImageReferences } }
-    var createdNetworks: [(name: String, labels: [String: String])] { lock.withLock { _createdNetworks } }
+    var createdNetworks: [(name: String, subnet: String?, labels: [String: String])] { lock.withLock { _createdNetworks } }
     var deletedNetworkIds: [String] { lock.withLock { _deletedNetworkIds } }
     var createdSpecs: [ContainerCreateSpec] { lock.withLock { _createdSpecs } }
     var deletedContainers: [(id: String, force: Bool)] { lock.withLock { _deletedContainers } }
@@ -204,9 +204,9 @@ final class MockContainerBackend: ContainerBackend, @unchecked Sendable {
         if let listNetworksError { throw listNetworksError }
         return networks
     }
-    func createNetwork(name: String, labels: [String: String]) async throws {
+    func createNetwork(name: String, subnet: String?, labels: [String: String]) async throws {
         if let createNetworkError { throw createNetworkError }
-        lock.withLock { _createdNetworks.append((name: name, labels: labels)) }
+        lock.withLock { _createdNetworks.append((name: name, subnet: subnet, labels: labels)) }
     }
     func deleteNetwork(id: String) async throws {
         if let deleteNetworkError { throw deleteNetworkError }

--- a/OrchardTests/NetworkServiceTests.swift
+++ b/OrchardTests/NetworkServiceTests.swift
@@ -54,11 +54,12 @@ func networkCreateParsesLabels() async {
     let backend = MockContainerBackend()
     let (service, alert) = makeNetworkService(backend)
 
-    let ok = await service.create(name: "app-net", labels: ["env=prod", "bare", "team=b=c"])
+    let ok = await service.create(name: "app-net", subnet: "192.168.1.0/24", labels: ["env=prod", "bare", "team=b=c"])
 
     #expect(ok == true)
     let recorded = backend.createdNetworks.first
     #expect(recorded?.name == "app-net")
+    #expect(recorded?.subnet == "192.168.1.0/24")  // threaded through, not dropped
     #expect(recorded?.labels == ["env": "prod", "bare": "", "team": "b=c"])  // maxSplits: 1
     #expect(alert.current == nil)
 }


### PR DESCRIPTION
Updates Orchard to build against Apple's `container` 1.1.0 (bumping the package pin from 0.12.3, which pulls containerization 0.35.0) and adapts the backend to the 1.x breaking API changes: the network client now returns `NetworkResource` (config/status split) instead of the removed `NetworkState` enum, image `fetch`/`pull`/`get` require a `ContainerSystemConfig` (loaded from the same TOML the CLI reads), `ClientImage.details()` is reconstructed from `index()` + per-platform `config(for:)`, and the smaller `kill`/`PublishPort`/`FilePath` signature changes are handled. This fixes the stop/force-stop/remove actions on container 1.x ([#54](https://github.com/andrew-waters/orchard/issues/54)), which silently failed while Orchard still linked the pre-1.0 client; the app and full test suite (139 tests) build and pass. The Terminal.app/iTerm AppleScript-permission half of #54 is out of scope and tracked separately.