### PR TITLE
fix: terminal launch failure (-1743)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Terminal and iTerm2 launch failures (-1743) caused by missing Apple Events permissions on hardened runtime builds.
+
 ## [2.1.3] - 2026-07-08
 
 ### Added

--- a/Orchard/Info.plist
+++ b/Orchard/Info.plist
@@ -10,6 +10,6 @@
 	<key>SUPublicEDKey</key>
 	<string>Ws/MYNAg4JzHzrjDzptZnj8Sun8S4kUnBUyIwx7FExk=</string>
 	<key>NSAppleEventsUsageDescription</key>
-	<string>Orchard needs to control Terminal to launch container shells.</string>
+	<string>Orchard needs to control terminal applications to launch container shells.</string>
 </dict>
 </plist>

--- a/Orchard/Info.plist
+++ b/Orchard/Info.plist
@@ -9,5 +9,7 @@
 	<string>https://orchard.andon.dev/appcast.xml</string>
 	<key>SUPublicEDKey</key>
 	<string>Ws/MYNAg4JzHzrjDzptZnj8Sun8S4kUnBUyIwx7FExk=</string>
+	<key>NSAppleEventsUsageDescription</key>
+	<string>Orchard needs to control Terminal to launch container shells.</string>
 </dict>
 </plist>

--- a/Orchard/Orchard.entitlements
+++ b/Orchard/Orchard.entitlements
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-<dict/>
+<dict>
+	<key>com.apple.security.automation.apple-events</key>
+	<true/>
+</dict>
 </plist>


### PR DESCRIPTION
## What does this PR do?

Fixes terminal launch failures (-1743 `errAEEventNotPermitted`) caused by missing Apple Events permissions on macOS Catalina and later. Hardened runtime applications require the `com.apple.security.automation.apple-events` entitlement and `NSAppleEventsUsageDescription` string in `Info.plist` to send AppleEvents to other applications (like Terminal and iTerm2). Since both were missing, macOS automatically denied the AppleEvent request without showing a prompt.

This PR adds:
1. `com.apple.security.automation.apple-events` entitlement to `Orchard/Orchard.entitlements`.
2. `NSAppleEventsUsageDescription` key to `Orchard/Info.plist` with a clear explanation.

## Related issues

Closes #64

## Screenshots / recording

N/A

## Checklist

- [x] The project builds and runs (`Orchard` scheme)
- [x] Tests pass (`⌘U` / `xcodebuild test`)
- [x] I've added an entry to `CHANGELOG.md` (Added / Changed / Fixed)
- [x] The change is focused on a single logical concern
