### PR TITLE
Link `container` tool in error alert

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Error message displayed when trying to start `container` now includes a download link if the binary could not be found.
+
 ## [2.1.3] - 2026-07-08
 
 ### Added

--- a/Orchard/Services/AlertCenter.swift
+++ b/Orchard/Services/AlertCenter.swift
@@ -1,10 +1,18 @@
 import Foundation
 
+struct AlertButton: Identifiable, Equatable {
+    let text: String
+    let url: URL?
+    
+    var id: String { text + (url?.absoluteString ?? "") }
+}
+
 /// A single alert to present to the user.
 struct AppAlert: Identifiable, Equatable {
     let id = UUID()
     let message: String
     let date: Date
+    let extraButtons: [AlertButton]
 }
 
 /// Where an error came from, which decides whether it's allowed to interrupt the user.
@@ -23,12 +31,12 @@ enum AlertSource {
 final class AlertCenter: ObservableObject {
     @Published var current: AppAlert?
 
-    func error(_ message: String, source: AlertSource = .user) {
+    func error(_ message: String, source: AlertSource = .user, alertButtons: [AlertButton] = []) {
         guard source == .user else {
             Log.ui.debug("suppressed background alert: \(message)")
             return
         }
-        current = AppAlert(message: message, date: Date())
+        current = AppAlert(message: message, date: Date(), extraButtons: alertButtons)
     }
 
     func error(_ error: OrchardError, source: AlertSource = .user) {

--- a/Orchard/Services/SystemService.swift
+++ b/Orchard/Services/SystemService.swift
@@ -108,7 +108,19 @@ final class SystemService: ObservableObject {
             Log.containers.debug("Container system started successfully")
             await onSystemStarted()
         } catch {
-            alertCenter.error("Failed to start system: \(error.localizedDescription)")
+            let nsError = error as NSError
+            if nsError.domain == NSCocoaErrorDomain, nsError.code == NSFileNoSuchFileError {
+                // `try!` is bad, but we know this is valid markdown
+                alertCenter.error("""
+                                   Failed to start system: \(error.localizedDescription)
+                                   Make sure Apple Container is installed.
+                                   """,
+                                  alertButtons: [
+                                    AlertButton(text: "Download Apple Container", url: URL(string: "https://github.com/apple/container?tab=readme-ov-file#initial-install"))
+                                  ])
+            } else {
+                alertCenter.error("Failed to start system: \(error.localizedDescription)")
+            }
             isSystemLoading = false
             await checkSystemStatus()
             Log.containers.error("Error starting system: \(error.localizedDescription)")

--- a/Orchard/Views/Layout/Content.swift
+++ b/Orchard/Views/Layout/Content.swift
@@ -51,6 +51,7 @@ struct ContentView: View {
     @State private var showingItemNavigatorPopover = false
 
     @Environment(\.openWindow) private var openWindow
+    @Environment(\.openURL) private var openURL
 
 
 
@@ -115,8 +116,11 @@ struct ContentView: View {
                 set: { presented in if !presented { alertCenter.dismiss() } }
             ),
             presenting: alertCenter.current
-        ) { _ in
+        ) { alert in
             Button("OK", role: .cancel) { alertCenter.dismiss() }
+            ForEach(alert.extraButtons) { button in
+                Button(button.text, role: .confirm) { if let url = button.url { openURL(url) } }
+            }
         } message: { alert in
             Text(alert.message)
         }


### PR DESCRIPTION
## What does this PR do?

If the `container` binary cannot be found, this adds a "Download Apple Container" button to the error alert. It is clear you need this in the README, but I can't be the only one who _thought_ they had it installed 😅.

## Related issues

None

## Screenshots / recording

<img width="2848" height="2048" alt="Error alert from failing to find container binary (Before)" src="https://github.com/user-attachments/assets/510b7f97-f9ba-4ea8-a196-f0c475a0f2dd" />
<img width="2848" height="2048" alt="Error alert from failing to find container binary (After)" src="https://github.com/user-attachments/assets/e0c18614-3f1e-404a-b830-063462d3aa71" />


## Checklist

- [x ] The project builds and runs (`Orchard` scheme)
- [ x] Tests pass (`⌘U` / `xcodebuild test`)
- [ x] I've added an entry to `CHANGELOG.md` (Added / Changed / Fixed)
- [ x] The change is focused on a single logical concern
