### PR TITLE
fix: make the containers' stop buttons in the menu-bar panel respond on first click

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Running containers' stop buttons in the menu-bar panel now respond on first click.
+
 ## [2.1.4] - 2026-07-23
 
 ### Added

--- a/Orchard/Views/Features/MenuBar/MenuBarDashboard.swift
+++ b/Orchard/Views/Features/MenuBar/MenuBarDashboard.swift
@@ -223,14 +223,20 @@ struct MenuBarView: View {
         }
         .contentShape(Rectangle())
         .onHover { if row.isRunning { setContainerHover(row.id, $0) } }
-        .popover(isPresented: containerHoverBinding(row.id), arrowEdge: .leading) {
-            ResourceHistoryPanel(
-                name: row.id,
-                cpuValues: containerHistory(id: row.id, cpu: true),
-                memValues: containerHistory(id: row.id, cpu: false),
-                cpuNow: String(format: "%.1f%%", row.cpuPercent),
-                memNow: ByteFormat.memory(row.memoryBytes)
-            )
+        // Anchor the popover to a zero-size overlay instead of the container row, so a
+        // click on the control button isn't consumed before reaching it.
+        .overlay(alignment: .leading) {
+            Color.clear
+                .frame(width: 0, height: 0)
+                .popover(isPresented: containerHoverBinding(row.id), arrowEdge: .leading) {
+                    ResourceHistoryPanel(
+                        name: row.id,
+                        cpuValues: containerHistory(id: row.id, cpu: true),
+                        memValues: containerHistory(id: row.id, cpu: false),
+                        cpuNow: String(format: "%.1f%%", row.cpuPercent),
+                        memNow: ByteFormat.memory(row.memoryBytes)
+                    )
+                }
         }
         .contextMenu { rowMenu(row) }
     }


### PR DESCRIPTION
## What does this PR do?

Fixes the running container's stop buttons in the menu bar panel not responding on the first click.

While the row's resource history popover was being presented, the first click was getting consumed before reaching the control button. Attaching the popover to a zero-size overlay fixes that.

An alternative way to fix this is to move the control button out of the row's hover area and not show the popover while hovering the stop button. If you prefer that, I'd be happy to do it.

## Related issues

N/A

## Screenshots / recording

Before: 
https://github.com/user-attachments/assets/5ea79352-581c-457c-bc44-9625a0a067fc

After:
https://github.com/user-attachments/assets/c5629643-f737-4f5c-8efe-1e7d2e6a037f


## Checklist

- [x] The project builds and runs (`Orchard` scheme)
- [x] Tests pass (`⌘U` / `xcodebuild test`)
- [x] I've added an entry to `CHANGELOG.md` (Added / Changed / Fixed)
- [x] The change is focused on a single logical concern
