### PR TITLE
Fix terminal launch on notarized builds: add apple-events entitlement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Opening a container terminal in Terminal.app or iTerm2 no longer fails with "Not authorized to send Apple events" on notarized builds: the app now carries the `com.apple.security.automation.apple-events` entitlement and a usage description, so macOS shows the Automation consent prompt. If permission is denied, the error now points to System Settings → Privacy & Security → Automation instead of dumping the raw AppleScript error ([#64](https://github.com/andrew-waters/orchard/issues/64)).
+
 ## [2.1.4] - 2026-07-23
 
 ### Added

--- a/Orchard.xcodeproj/project.pbxproj
+++ b/Orchard.xcodeproj/project.pbxproj
@@ -412,7 +412,7 @@
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Orchard/Info.plist;
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.developer-tools";
-				INFOPLIST_KEY_NSAppleEventsUsageDescription = "";
+				INFOPLIST_KEY_NSAppleEventsUsageDescription = "Orchard opens container shells in your preferred terminal app (Terminal or iTerm2), which requires permission to send it Apple events.";
 				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphoneos*]" = YES;
 				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphonesimulator*]" = YES;
 				"INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents[sdk=iphoneos*]" = YES;
@@ -453,7 +453,7 @@
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Orchard/Info.plist;
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.developer-tools";
-				INFOPLIST_KEY_NSAppleEventsUsageDescription = "";
+				INFOPLIST_KEY_NSAppleEventsUsageDescription = "Orchard opens container shells in your preferred terminal app (Terminal or iTerm2), which requires permission to send it Apple events.";
 				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphoneos*]" = YES;
 				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphonesimulator*]" = YES;
 				"INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents[sdk=iphoneos*]" = YES;

--- a/Orchard/Orchard.entitlements
+++ b/Orchard/Orchard.entitlements
@@ -1,5 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-<dict/>
+<dict>
+	<!-- Required for TerminalLauncher to drive Terminal.app and iTerm2 via
+	     AppleScript under the hardened runtime; without it, notarized builds
+	     are refused with "Not authorized to send Apple events" (#64). -->
+	<key>com.apple.security.automation.apple-events</key>
+	<true/>
+</dict>
 </plist>

--- a/Orchard/Services/TerminalLauncher.swift
+++ b/Orchard/Services/TerminalLauncher.swift
@@ -98,9 +98,33 @@ final class TerminalLauncher: ObservableObject {
 
         if let error = error {
             Log.ui.error("❌ AppleScript error: \(String(describing: error))")
-            alertCenter.error("Failed to open terminal: \(String(describing: error))")
+            alertCenter.error(Self.userMessage(for: error))
         } else if let result = result {
             Log.ui.debug("✓ AppleScript executed: \(String(describing: result))")
+        }
+    }
+
+    /// Translates an `NSAppleScript` error dictionary into something actionable.
+    /// Automation refusals (errAEEventNotPermitted / errAEPrivilegeError) get pointed
+    /// at System Settings instead of dumping the raw error dictionary (#64).
+    nonisolated static func userMessage(for error: NSDictionary) -> String {
+        let code = (error[NSAppleScript.errorNumber] as? Int) ?? 0
+        let appName = (error[NSAppleScript.errorAppName] as? String) ?? "your terminal app"
+
+        switch code {
+        case -1743, -10004: // errAEEventNotPermitted, errAEPrivilegeError
+            return """
+            Orchard isn't authorized to control \(appName). \
+            Allow it under System Settings → Privacy & Security → Automation → Orchard, \
+            then try again.
+            """
+        case -600, -609: // procNotFound, connectionInvalid
+            return "\(appName) isn't running and couldn't be launched. Open it once manually, then try again."
+        default:
+            let message = (error[NSAppleScript.errorBriefMessage] as? String)
+                ?? (error[NSAppleScript.errorMessage] as? String)
+                ?? String(describing: error)
+            return "Failed to open terminal: \(message)"
         }
     }
 }

--- a/Orchard/Services/TerminalLauncher.swift
+++ b/Orchard/Services/TerminalLauncher.swift
@@ -121,9 +121,11 @@ final class TerminalLauncher: ObservableObject {
         case -600, -609: // procNotFound, connectionInvalid
             return "\(appName) isn't running and couldn't be launched. Open it once manually, then try again."
         default:
+            // Never dump the raw error dictionary at the user; the full details are
+            // already logged. Fall back to a stable message carrying the error code.
             let message = (error[NSAppleScript.errorBriefMessage] as? String)
                 ?? (error[NSAppleScript.errorMessage] as? String)
-                ?? String(describing: error)
+                ?? "An unknown AppleScript error occurred (code \(code))."
             return "Failed to open terminal: \(message)"
         }
     }

--- a/OrchardTests/TerminalLauncherTests.swift
+++ b/OrchardTests/TerminalLauncherTests.swift
@@ -1,0 +1,55 @@
+import Foundation
+import Testing
+@testable import Orchard
+
+@Test("TerminalLauncher: automation refusal points at System Settings")
+func terminalLauncherNotAuthorizedMessage() {
+    let error: NSDictionary = [
+        NSAppleScript.errorNumber: -1743,
+        NSAppleScript.errorAppName: "Terminal",
+        NSAppleScript.errorBriefMessage: "Not authorized to send Apple events to Terminal.",
+    ]
+    let message = TerminalLauncher.userMessage(for: error)
+    #expect(message.contains("Terminal"))
+    #expect(message.contains("Privacy & Security"))
+    #expect(message.contains("Automation"))
+}
+
+@Test("TerminalLauncher: privilege error is treated as an automation refusal")
+func terminalLauncherPrivilegeErrorMessage() {
+    let error: NSDictionary = [
+        NSAppleScript.errorNumber: -10004,
+        NSAppleScript.errorAppName: "iTerm2",
+    ]
+    let message = TerminalLauncher.userMessage(for: error)
+    #expect(message.contains("iTerm2"))
+    #expect(message.contains("Automation"))
+}
+
+@Test("TerminalLauncher: app-not-running errors suggest opening the app")
+func terminalLauncherAppNotRunningMessage() {
+    let error: NSDictionary = [
+        NSAppleScript.errorNumber: -600,
+        NSAppleScript.errorAppName: "iTerm2",
+    ]
+    let message = TerminalLauncher.userMessage(for: error)
+    #expect(message.contains("iTerm2"))
+    #expect(message.contains("isn't running"))
+}
+
+@Test("TerminalLauncher: unknown errors fall back to the brief message")
+func terminalLauncherUnknownErrorMessage() {
+    let error: NSDictionary = [
+        NSAppleScript.errorNumber: -2700,
+        NSAppleScript.errorBriefMessage: "Some other failure.",
+    ]
+    let message = TerminalLauncher.userMessage(for: error)
+    #expect(message.contains("Failed to open terminal"))
+    #expect(message.contains("Some other failure."))
+}
+
+@Test("TerminalLauncher: missing error fields still produce a usable message")
+func terminalLauncherMissingFieldsMessage() {
+    let message = TerminalLauncher.userMessage(for: [:])
+    #expect(message.contains("Failed to open terminal"))
+}

--- a/OrchardTests/TerminalLauncherTests.swift
+++ b/OrchardTests/TerminalLauncherTests.swift
@@ -26,10 +26,10 @@ func terminalLauncherPrivilegeErrorMessage() {
     #expect(message.contains("Automation"))
 }
 
-@Test("TerminalLauncher: app-not-running errors suggest opening the app")
-func terminalLauncherAppNotRunningMessage() {
+@Test("TerminalLauncher: app-not-running errors suggest opening the app", arguments: [-600, -609])
+func terminalLauncherAppNotRunningMessage(code: Int) {
     let error: NSDictionary = [
-        NSAppleScript.errorNumber: -600,
+        NSAppleScript.errorNumber: code,
         NSAppleScript.errorAppName: "iTerm2",
     ]
     let message = TerminalLauncher.userMessage(for: error)
@@ -48,8 +48,11 @@ func terminalLauncherUnknownErrorMessage() {
     #expect(message.contains("Some other failure."))
 }
 
-@Test("TerminalLauncher: missing error fields still produce a usable message")
+@Test("TerminalLauncher: missing error fields still produce a usable message, not the raw dictionary")
 func terminalLauncherMissingFieldsMessage() {
-    let message = TerminalLauncher.userMessage(for: [:])
+    let error: NSDictionary = [NSAppleScript.errorNumber: -2700, "SomeInternalKey": "noise"]
+    let message = TerminalLauncher.userMessage(for: error)
     #expect(message.contains("Failed to open terminal"))
+    #expect(message.contains("-2700"))
+    #expect(!message.contains("SomeInternalKey"))
 }


### PR DESCRIPTION
## What does this PR do?

Fixes "Not authorized to send Apple events to Terminal" when opening a container shell in Terminal.app or iTerm2 from a notarized build.

Release builds sign with the hardened runtime (`OTHER_CODE_SIGN_FLAGS="--options=runtime"`), which refuses to send Apple events unless the app carries the `com.apple.security.automation.apple-events` entitlement. `Orchard.entitlements` was an empty dict and `NSAppleEventsUsageDescription` was an empty string, so macOS blocked the AppleScript outright and Orchard could never even appear under System Settings > Privacy & Security > Automation, which is exactly what was reported in #64.

Changes:

- **`Orchard.entitlements`**: add `com.apple.security.automation.apple-events`
- **`project.pbxproj`**: set a real `NSAppleEventsUsageDescription` (Debug + Release) so the Automation consent prompt shows a meaningful message
- **`TerminalLauncher`**: map AppleScript errors to actionable messages instead of dumping the raw error dictionary:
  - `-1743` / `-10004` (not authorized): points the user at System Settings > Privacy & Security > Automation
  - `-600` / `-609` (app not running): suggests opening the terminal app once manually
  - anything else: falls back to the script's brief message
- **`TerminalLauncherTests`**: 5 unit tests covering each mapping branch

Ghostty is unaffected (launched via `open`, not AppleScript).

Note for verification: the entitlement only takes effect on a signed build. The consent prompt should appear on first terminal launch of the next notarized release.

## Related issues

Closes #64

## Screenshots / recording

No UI change, error alert copy only.

## Checklist

- [x] The project builds and runs (`Orchard` scheme)
- [x] Tests pass (`⌘U` / `xcodebuild test`) - 201/201
- [x] I've added an entry to `CHANGELOG.md` (Added / Changed / Fixed)
- [x] The change is focused on a single logical concern
