### PR TITLE
Fix Edit Configuration dropping the executable from Command Override

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- Edit Configuration no longer drops the executable from the Command Override field: the form now shows the full command (`sleep 3600`, not just `3600`), so saving doesn't corrupt the container's process configuration. Quoted arguments (`sh -c "echo hi"`) now also survive the round-trip ([#42](https://github.com/andrew-waters/orchard/issues/42)).
 - Opening a container terminal in Terminal.app or iTerm2 no longer fails with "Not authorized to send Apple events" on notarized builds: the app now carries the `com.apple.security.automation.apple-events` entitlement and a usage description, so macOS shows the Automation consent prompt. If permission is denied, the error now points to System Settings → Privacy & Security → Automation instead of dumping the raw AppleScript error ([#64](https://github.com/andrew-waters/orchard/issues/64)).
 
 ## [2.1.4] - 2026-07-23

--- a/Orchard/Services/CLIParsers.swift
+++ b/Orchard/Services/CLIParsers.swift
@@ -166,3 +166,64 @@ func parseDockerHubSearch(data: Data) -> [RegistrySearchResult] {
         )
     }
 }
+
+// MARK: - Command-line splitting
+
+/// Splits a command-line string into argv, honouring single quotes, double quotes,
+/// and backslash escapes (outside single quotes) - so `sh -c "echo hi"` yields three
+/// arguments, not four. Lenient: an unterminated quote consumes to end of string.
+func splitCommandLine(_ line: String) -> [String] {
+    var args: [String] = []
+    var current = ""
+    var inSingle = false
+    var inDouble = false
+    var escaped = false
+    var hasToken = false
+
+    for char in line {
+        if escaped {
+            current.append(char)
+            escaped = false
+            continue
+        }
+        switch char {
+        case "\\" where !inSingle:
+            escaped = true
+            hasToken = true
+        case "'" where !inDouble:
+            inSingle.toggle()
+            hasToken = true
+        case "\"" where !inSingle:
+            inDouble.toggle()
+            hasToken = true
+        case " ", "\t" :
+            if inSingle || inDouble {
+                current.append(char)
+            } else if hasToken {
+                args.append(current)
+                current = ""
+                hasToken = false
+            }
+        default:
+            current.append(char)
+            hasToken = true
+        }
+    }
+    if hasToken { args.append(current) }
+    return args
+}
+
+/// Joins argv back into a command-line string that `splitCommandLine` round-trips:
+/// arguments containing whitespace, quotes, or backslashes are double-quoted with
+/// backslash escapes.
+func joinCommandLine(_ args: [String]) -> String {
+    args.map { arg in
+        if arg.isEmpty { return "\"\"" }
+        let needsQuoting = arg.contains(where: { $0 == " " || $0 == "\t" || $0 == "'" || $0 == "\"" || $0 == "\\" })
+        guard needsQuoting else { return arg }
+        let escaped = arg
+            .replacingOccurrences(of: "\\", with: "\\\\")
+            .replacingOccurrences(of: "\"", with: "\\\"")
+        return "\"\(escaped)\""
+    }.joined(separator: " ")
+}

--- a/Orchard/Services/ContainerListService.swift
+++ b/Orchard/Services/ContainerListService.swift
@@ -414,7 +414,8 @@ final class ContainerListService: ObservableObject {
 
             var commandArgs: [String] = []
             if !config.commandOverride.isEmpty {
-                commandArgs = config.commandOverride.split(separator: " ").map(String.init)
+                // Quote-aware split so `sh -c "echo hi"` stays three arguments (#42).
+                commandArgs = splitCommandLine(config.commandOverride)
             }
 
             let spec = ContainerCreateSpec(

--- a/Orchard/Views/Features/Containers/EditContainer.swift
+++ b/Orchard/Views/Features/Containers/EditContainer.swift
@@ -40,7 +40,11 @@ struct EditContainerView: View {
             portMappings: [], // Port mappings not available in container config
             volumeMappings: volumes,
             workingDirectory: container.configuration.initProcess.workingDirectory,
-            commandOverride: container.configuration.initProcess.arguments.joined(separator: " ")
+            // The executable lives separately from the arguments in the process config;
+            // rebuild the full command line so editing doesn't silently drop it (#42).
+            commandOverride: joinCommandLine(
+                [container.configuration.initProcess.executable] + container.configuration.initProcess.arguments
+            )
         ))
     }
 

--- a/OrchardTests/CLIParserTests.swift
+++ b/OrchardTests/CLIParserTests.swift
@@ -284,3 +284,50 @@ func stopDiagnosisHealthyBoot() {
     ]
     #expect(!MachineImageAdvisor.logsIndicateMissingInit(lines))
 }
+
+// MARK: - Command-line splitting (#42)
+
+@Test("splitCommandLine: plain words split on whitespace")
+func splitCommandLinePlain() {
+    #expect(splitCommandLine("sleep 3600") == ["sleep", "3600"])
+    #expect(splitCommandLine("  nginx   -g  ") == ["nginx", "-g"])
+}
+
+@Test("splitCommandLine: double quotes keep spaces together")
+func splitCommandLineDoubleQuotes() {
+    #expect(splitCommandLine("sh -c \"echo hi\"") == ["sh", "-c", "echo hi"])
+    #expect(splitCommandLine("nginx -g \"daemon off;\"") == ["nginx", "-g", "daemon off;"])
+}
+
+@Test("splitCommandLine: single quotes and escapes")
+func splitCommandLineSingleQuotes() {
+    #expect(splitCommandLine("echo 'a b' c\\ d") == ["echo", "a b", "c d"])
+    #expect(splitCommandLine("echo \\\"hi\\\"") == ["echo", "\"hi\""])
+}
+
+@Test("splitCommandLine: empty and quoted-empty arguments")
+func splitCommandLineEmpty() {
+    #expect(splitCommandLine("") == [])
+    #expect(splitCommandLine("   ") == [])
+    #expect(splitCommandLine("cmd \"\"") == ["cmd", ""])
+}
+
+@Test("joinCommandLine: quotes only what needs quoting")
+func joinCommandLinePlain() {
+    #expect(joinCommandLine(["sleep", "3600"]) == "sleep 3600")
+    #expect(joinCommandLine(["nginx", "-g", "daemon off;"]) == "nginx -g \"daemon off;\"")
+}
+
+@Test("join/split round-trips argv exactly")
+func commandLineRoundTrip() {
+    let cases: [[String]] = [
+        ["sleep", "3600"],
+        ["sh", "-c", "echo hi && sleep 1"],
+        ["nginx", "-g", "daemon off;"],
+        ["printf", "%s\\n", "a b", "", "c\"d", "e'f"],
+        ["/usr/local/bin/my tool", "--flag=va lue"],
+    ]
+    for argv in cases {
+        #expect(splitCommandLine(joinCommandLine(argv)) == argv)
+    }
+}


### PR DESCRIPTION
## What does this PR do?

Fixes Edit Configuration silently dropping the executable from the Command Override field.

The process config stores the executable separately from its arguments (`executable: "sleep"`, `arguments: ["3600"]`), but the edit form prefilled Command Override from `initProcess.arguments` alone. So a container created with `sleep 3600` showed `3600` in the box, and Save & Recreate persisted the corrupted command.

Changes:

- **`EditContainer`**: prefill Command Override from `executable` + `arguments` rebuilt into one command line
- **`CLIParsers`**: new `splitCommandLine` / `joinCommandLine` helpers, quote- and escape-aware (double quotes, single quotes, backslash escapes; lenient on malformed input, matching the file's existing parsers). This also fixes a second latent bug: arguments containing spaces (`sh -c "echo hi"`, `nginx -g "daemon off;"`) previously got mangled by the naive whitespace split on save
- **`ContainerListService`**: create/recreate now uses the quote-aware split
- **`CLIParserTests`**: 6 new tests, including exact argv round-trips

Note: this branch is based on `prd-64` (#75); it will show that commit until #75 merges, after which this diff reduces to the #42 fix alone.

## Related issues

Closes #42

## Screenshots / recording

No layout change, field contents only: Command Override now shows `sleep 3600` instead of `3600` when editing a container created with that override.

## Checklist

- [x] The project builds and runs (`Orchard` scheme)
- [x] Tests pass (`⌘U` / `xcodebuild test`) - 207/207
- [x] I've added an entry to `CHANGELOG.md` (Added / Changed / Fixed)
- [x] The change is focused on a single logical concern
