### PR TITLE
Make the detached-mode toggle do something

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- Unchecking "Run in detached mode (background)" now does what it says: after the container starts, Orchard opens your preferred terminal attached to it. The toggle no longer appears in the Edit Configuration sheet, where recreation always happens in the background ([#43](https://github.com/andrew-waters/orchard/issues/43)).
 - Opening a container terminal in Terminal.app or iTerm2 no longer fails with "Not authorized to send Apple events" on notarized builds: the app now carries the `com.apple.security.automation.apple-events` entitlement and a usage description, so macOS shows the Automation consent prompt. If permission is denied, the error now points to System Settings → Privacy & Security → Automation instead of dumping the raw AppleScript error ([#64](https://github.com/andrew-waters/orchard/issues/64)).
 
 ## [2.1.4] - 2026-07-23

--- a/Orchard/Views/Features/Containers/ContainerConfigForm.swift
+++ b/Orchard/Views/Features/Containers/ContainerConfigForm.swift
@@ -184,8 +184,18 @@ struct ContainerConfigForm: View {
             }
 
             VStack(alignment: .leading, spacing: 8) {
-                Toggle("Run in detached mode (background)", isOn: $config.detached)
-                    .font(.subheadline)
+                // Recreating from the edit sheet always happens in the background, so the
+                // detached toggle only appears (and only acts) when running a container.
+                if mode == .run {
+                    Toggle("Run in detached mode (background)", isOn: $config.detached)
+                        .font(.subheadline)
+
+                    if !config.detached {
+                        Text("A terminal attached to the container opens once it starts")
+                            .font(.caption)
+                            .foregroundColor(.secondary)
+                    }
+                }
 
                 Toggle("Remove container after it stops", isOn: $config.removeAfterStop)
                     .font(.subheadline)

--- a/Orchard/Views/Features/Containers/RunContainer.swift
+++ b/Orchard/Views/Features/Containers/RunContainer.swift
@@ -3,6 +3,7 @@ import AppKit
 
 struct RunContainerView: View {
     @EnvironmentObject var containerListService: ContainerListService
+    @EnvironmentObject var terminalLauncher: TerminalLauncher
     @Environment(\.dismiss) var dismiss
 
     let imageName: String
@@ -99,10 +100,17 @@ struct RunContainerView: View {
 
         isRunning = true
         Task {
-            await containerListService.runContainer(config: config)
+            let started = await containerListService.runContainer(config: config)
             await MainActor.run {
                 isRunning = false
                 dismiss()
+                // Non-detached run: open the user's preferred terminal attached to the
+                // container. The service uses config.name as the container id (the Run
+                // button is disabled while the name is empty), and the container is
+                // already started by the time runContainer returns (#43).
+                if started && !config.detached {
+                    terminalLauncher.openTerminal(for: config.name)
+                }
             }
         }
     }


### PR DESCRIPTION
## What does this PR do?

Makes the "Run in detached mode (background)" toggle actually do something. It was bound to the form model, but nothing ever read the flag, so unchecking it had no effect.

Changes:

- **`RunContainerView`**: when the toggle is unchecked and the run succeeds, Orchard opens your preferred terminal (Terminal, iTerm2 or Ghostty) attached to the new container via `TerminalLauncher`
- **`ContainerConfigForm`**: the toggle now only appears in run mode. Recreating from the Edit Configuration sheet always happens in the background, so showing it there perpetuated the same dead-control confusion. A caption under the unchecked toggle explains what will happen
- CHANGELOG entry

Scope note: this attaches an exec'd shell (`container exec -it <id> sh`), not the init process's stdio. True `docker run -it` semantics would need the container created with `terminal: true` plus stdio attach, which is a much larger change; this delivers what the issue asked for (a terminal window on the running container) with the existing machinery.

This branch is based on `prd-64` (#75) deliberately: without the apple-events entitlement fix, the attach would immediately fail with the exact error from #64.

## Related issues

Closes #43

## Screenshots / recording

The toggle and its new caption live in the existing Run Container form; no layout change beyond the caption line. Behaviour is only observable on a live run.

## Checklist

- [x] The project builds and runs (`Orchard` scheme)
- [x] Tests pass (`⌘U` / `xcodebuild test`) - 201/201
- [x] I've added an entry to `CHANGELOG.md` (Added / Changed / Fixed)
- [x] The change is focused on a single logical concern
