### PR TITLE
Add CPU and memory allocation to the container create/edit forms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Containers can now be created with a chosen CPU and memory allocation, and both can be changed later from Edit Configuration (via the usual stop/recreate flow). Previously every container silently got the runtime defaults of 4 CPUs and 1 GB with no way to change them in the GUI ([#73](https://github.com/andrew-waters/orchard/issues/73)).
+
 ### Fixed
 - Unchecking "Run in detached mode (background)" now does what it says: after the container starts, Orchard opens your preferred terminal attached to it. The toggle no longer appears in the Edit Configuration sheet, where recreation always happens in the background ([#43](https://github.com/andrew-waters/orchard/issues/43)).
 - Opening a container terminal in Terminal.app or iTerm2 no longer fails with "Not authorized to send Apple events" on notarized builds: the app now carries the `com.apple.security.automation.apple-events` entitlement and a usage description, so macOS shows the Automation consent prompt. If permission is denied, the error now points to System Settings → Privacy & Security → Automation instead of dumping the raw AppleScript error ([#64](https://github.com/andrew-waters/orchard/issues/64)).

--- a/Orchard/Models.swift
+++ b/Orchard/Models.swift
@@ -737,6 +737,10 @@ struct ContainerRunConfig: Equatable {
     var network: String = ""
     /// Labels to stamp on the container at creation (e.g. the sandbox marker).
     var labels: [String: String] = [:]
+    /// Resource allocation applied at create time. Defaults match the runtime's own
+    /// (4 CPUs, 1 GB) so an untouched form behaves exactly as before.
+    var cpus: Int = 4
+    var memoryGiB: Int = 1
 
     struct EnvironmentVariable: Identifiable, Equatable {
         let id = UUID()

--- a/Orchard/Models.swift
+++ b/Orchard/Models.swift
@@ -738,9 +738,21 @@ struct ContainerRunConfig: Equatable {
     /// Labels to stamp on the container at creation (e.g. the sandbox marker).
     var labels: [String: String] = [:]
     /// Resource allocation applied at create time. Defaults match the runtime's own
-    /// (4 CPUs, 1 GB) so an untouched form behaves exactly as before.
+    /// (4 CPUs, 1 GB) so an untouched form behaves exactly as before. Memory is carried
+    /// in bytes so a value that isn't a whole number of GB (e.g. a CLI-created 1.5 GB
+    /// container) survives edit and recovery untouched; the form edits it in whole GB.
     var cpus: Int = 4
-    var memoryGiB: Int = 1
+    var memoryBytes: UInt64 = ContainerRunConfig.bytesPerGiB
+
+    static let bytesPerGiB: UInt64 = 1_073_741_824
+
+    /// Whole-GB view of `memoryBytes` for the form's stepper: reads rounded to the
+    /// nearest GB (never below 1), writes exact whole GB. Only a user edit goes through
+    /// the setter, so an untouched non-integral value keeps its exact byte count.
+    var memoryGiB: Int {
+        get { max(1, Int(clamping: (memoryBytes + Self.bytesPerGiB / 2) / Self.bytesPerGiB)) }
+        set { memoryBytes = UInt64(max(1, newValue)) * Self.bytesPerGiB }
+    }
 
     struct EnvironmentVariable: Identifiable, Equatable {
         let id = UUID()

--- a/Orchard/Services/ContainerBackend.swift
+++ b/Orchard/Services/ContainerBackend.swift
@@ -36,9 +36,9 @@ struct ContainerCreateSpec: Sendable {
     let dnsDomain: String
     let networkName: String
     let autoRemove: Bool
-    /// CPU cores and memory allocated to the container's VM.
+    /// CPU cores and memory (in bytes) allocated to the container's VM.
     let cpus: Int
-    let memoryGiB: Int
+    let memoryBytes: UInt64
     /// Key/value labels stamped on the container at creation - e.g. the sandbox marker
     /// that lets the Sandboxes view recognise a container Orchard wired to a model.
     var labels: [String: String] = [:]
@@ -232,7 +232,7 @@ struct LiveContainerBackend: ContainerBackend {
         containerConfig.dns = dns
         containerConfig.labels = spec.labels
         containerConfig.resources.cpus = spec.cpus
-        containerConfig.resources.memoryInBytes = UInt64(spec.memoryGiB) * 1_073_741_824
+        containerConfig.resources.memoryInBytes = spec.memoryBytes
 
         let builtinNetworkId = try await NetworkClient().builtin?.id
         let networkId = spec.networkName.isEmpty ? (builtinNetworkId ?? NetworkClient.defaultNetworkName) : spec.networkName

--- a/Orchard/Services/ContainerBackend.swift
+++ b/Orchard/Services/ContainerBackend.swift
@@ -36,6 +36,9 @@ struct ContainerCreateSpec: Sendable {
     let dnsDomain: String
     let networkName: String
     let autoRemove: Bool
+    /// CPU cores and memory allocated to the container's VM.
+    let cpus: Int
+    let memoryGiB: Int
     /// Key/value labels stamped on the container at creation - e.g. the sandbox marker
     /// that lets the Sandboxes view recognise a container Orchard wired to a model.
     var labels: [String: String] = [:]
@@ -228,6 +231,8 @@ struct LiveContainerBackend: ContainerBackend {
         containerConfig.publishedPorts = ports
         containerConfig.dns = dns
         containerConfig.labels = spec.labels
+        containerConfig.resources.cpus = spec.cpus
+        containerConfig.resources.memoryInBytes = UInt64(spec.memoryGiB) * 1_073_741_824
 
         let builtinNetworkId = try await NetworkClient().builtin?.id
         let networkId = spec.networkName.isEmpty ? (builtinNetworkId ?? NetworkClient.defaultNetworkName) : spec.networkName

--- a/Orchard/Services/ContainerListService.swift
+++ b/Orchard/Services/ContainerListService.swift
@@ -377,7 +377,9 @@ final class ContainerListService: ObservableObject {
             volumeMappings: volumeMappings,
             workingDirectory: config.initProcess.workingDirectory,
             dnsDomain: config.dns.domain ?? "",
-            network: snapshot.networks.first?.network ?? ""
+            network: snapshot.networks.first?.network ?? "",
+            cpus: config.resources.cpus,
+            memoryGiB: max(1, config.resources.memoryInBytes / 1_073_741_824)
         )
 
         let started = await runContainer(config: runConfig)
@@ -428,6 +430,8 @@ final class ContainerListService: ObservableObject {
                 dnsDomain: config.dnsDomain,
                 networkName: config.network,
                 autoRemove: config.removeAfterStop,
+                cpus: config.cpus,
+                memoryGiB: config.memoryGiB,
                 labels: config.labels
             )
             try await backend.createContainer(spec)

--- a/Orchard/Services/ContainerListService.swift
+++ b/Orchard/Services/ContainerListService.swift
@@ -379,7 +379,8 @@ final class ContainerListService: ObservableObject {
             dnsDomain: config.dns.domain ?? "",
             network: snapshot.networks.first?.network ?? "",
             cpus: config.resources.cpus,
-            memoryGiB: max(1, config.resources.memoryInBytes / 1_073_741_824)
+            // Exact bytes, not a GB round-trip: recovery must never resize a container.
+            memoryBytes: UInt64(clamping: config.resources.memoryInBytes)
         )
 
         let started = await runContainer(config: runConfig)
@@ -430,8 +431,11 @@ final class ContainerListService: ObservableObject {
                 dnsDomain: config.dnsDomain,
                 networkName: config.network,
                 autoRemove: config.removeAfterStop,
-                cpus: config.cpus,
-                memoryGiB: config.memoryGiB,
+                // Clamped here so no caller can trap the backend's UInt64 math with a
+                // negative or zero allocation. Upper bounds are deliberately not
+                // enforced: the runtime accepts overcommitted VMs.
+                cpus: max(1, config.cpus),
+                memoryBytes: max(1_048_576, config.memoryBytes),
                 labels: config.labels
             )
             try await backend.createContainer(spec)

--- a/Orchard/Views/Features/Containers/ContainerConfigForm.swift
+++ b/Orchard/Views/Features/Containers/ContainerConfigForm.swift
@@ -201,7 +201,42 @@ struct ContainerConfigForm: View {
                     .font(.subheadline)
             }
 
+            resourcesConfigView
+
             Spacer()
+        }
+    }
+
+    /// CPU/memory allocation, mirroring the machine forms. The runtime applies these at
+    /// create time only, so editing goes through the usual stop/recreate flow.
+    private var resourcesConfigView: some View {
+        let hostCores = ProcessInfo.processInfo.processorCount
+        let hostGiB = max(1, Int(ProcessInfo.processInfo.physicalMemory / 1_073_741_824))
+
+        return VStack(alignment: .leading, spacing: 12) {
+            Text("Resources")
+                .font(.subheadline)
+                .fontWeight(.medium)
+
+            HStack(spacing: 24) {
+                VStack(alignment: .leading, spacing: 4) {
+                    Text("CPUs")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                    NumericStepperField(value: $config.cpus, range: 1...hostCores)
+                }
+
+                VStack(alignment: .leading, spacing: 4) {
+                    Text("Memory")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                    NumericStepperField(value: $config.memoryGiB, range: 1...hostGiB, unit: "GB")
+                }
+            }
+
+            Text("Cores and RAM allocated to the container's VM (host has \(hostCores) cores, \(hostGiB) GB)")
+                .font(.caption)
+                .foregroundColor(.secondary)
         }
     }
 

--- a/Orchard/Views/Features/Containers/EditContainer.swift
+++ b/Orchard/Views/Features/Containers/EditContainer.swift
@@ -40,7 +40,9 @@ struct EditContainerView: View {
             portMappings: [], // Port mappings not available in container config
             volumeMappings: volumes,
             workingDirectory: container.configuration.initProcess.workingDirectory,
-            commandOverride: container.configuration.initProcess.arguments.joined(separator: " ")
+            commandOverride: container.configuration.initProcess.arguments.joined(separator: " "),
+            cpus: container.configuration.resources.cpus,
+            memoryGiB: max(1, container.configuration.resources.memoryInBytes / 1_073_741_824)
         ))
     }
 

--- a/Orchard/Views/Features/Containers/EditContainer.swift
+++ b/Orchard/Views/Features/Containers/EditContainer.swift
@@ -42,7 +42,8 @@ struct EditContainerView: View {
             workingDirectory: container.configuration.initProcess.workingDirectory,
             commandOverride: container.configuration.initProcess.arguments.joined(separator: " "),
             cpus: container.configuration.resources.cpus,
-            memoryGiB: max(1, container.configuration.resources.memoryInBytes / 1_073_741_824)
+            // Exact bytes: a non-integral allocation only changes if the user edits it.
+            memoryBytes: UInt64(clamping: container.configuration.resources.memoryInBytes)
         ))
     }
 

--- a/OrchardTests/ContainerServiceTests.swift
+++ b/OrchardTests/ContainerServiceTests.swift
@@ -80,7 +80,7 @@ func specResourceDefaults() async {
 
     let spec = backend.createdSpecs.first
     #expect(spec?.cpus == 4)
-    #expect(spec?.memoryGiB == 1)
+    #expect(spec?.memoryBytes == 1_073_741_824)
 }
 
 @MainActor
@@ -95,7 +95,49 @@ func specResourcePassthrough() async {
 
     let spec = backend.createdSpecs.first
     #expect(spec?.cpus == 6)
-    #expect(spec?.memoryGiB == 8)
+    #expect(spec?.memoryBytes == 8_589_934_592)
+}
+
+@MainActor
+@Test("Spec: a non-integral memory allocation passes through in exact bytes")
+func specResourceExactBytes() async {
+    let backend = MockContainerBackend()
+    let service = makeService(backend: backend)
+    var config = ContainerRunConfig(name: "web", image: "nginx")
+    config.memoryBytes = 1_610_612_736   // 1.5 GB, e.g. from a CLI-created container
+    await service.containerListService.runContainer(config: config)
+
+    #expect(backend.createdSpecs.first?.memoryBytes == 1_610_612_736)
+}
+
+@MainActor
+@Test("Spec: invalid resource values are clamped, never trapped")
+func specResourceClamping() async {
+    let backend = MockContainerBackend()
+    let service = makeService(backend: backend)
+    var config = ContainerRunConfig(name: "web", image: "nginx")
+    config.cpus = -2
+    config.memoryBytes = 0
+    await service.containerListService.runContainer(config: config)
+
+    let spec = backend.createdSpecs.first
+    #expect(spec?.cpus == 1)
+    #expect(spec?.memoryBytes == 1_048_576)
+}
+
+@Test("Config: the GB accessor rounds for display and floors edits at 1 GB")
+func memoryGiBAccessor() {
+    var config = ContainerRunConfig(name: "web", image: "nginx")
+
+    config.memoryBytes = 1_610_612_736            // 1.5 GB reads as 2
+    #expect(config.memoryGiB == 2)
+    config.memoryBytes = 1_400_000_000            // ~1.3 GB reads as 1
+    #expect(config.memoryGiB == 1)
+
+    config.memoryGiB = 3                          // edits write exact whole GB
+    #expect(config.memoryBytes == 3_221_225_472)
+    config.memoryGiB = -5                         // nonsense edits floor at 1 GB
+    #expect(config.memoryBytes == 1_073_741_824)
 }
 
 // MARK: - Service state transitions

--- a/OrchardTests/ContainerServiceTests.swift
+++ b/OrchardTests/ContainerServiceTests.swift
@@ -71,6 +71,33 @@ func specCommandAndName() async {
     #expect(spec?.id.isEmpty == false)   // empty name → generated id
 }
 
+@MainActor
+@Test("Spec: resources default to the runtime's own values (4 CPUs, 1 GB)")
+func specResourceDefaults() async {
+    let backend = MockContainerBackend()
+    let service = makeService(backend: backend)
+    await service.containerListService.runContainer(config: ContainerRunConfig(name: "web", image: "nginx"))
+
+    let spec = backend.createdSpecs.first
+    #expect(spec?.cpus == 4)
+    #expect(spec?.memoryGiB == 1)
+}
+
+@MainActor
+@Test("Spec: configured CPUs and memory carry through to the create spec")
+func specResourcePassthrough() async {
+    let backend = MockContainerBackend()
+    let service = makeService(backend: backend)
+    var config = ContainerRunConfig(name: "web", image: "nginx")
+    config.cpus = 6
+    config.memoryGiB = 8
+    await service.containerListService.runContainer(config: config)
+
+    let spec = backend.createdSpecs.first
+    #expect(spec?.cpus == 6)
+    #expect(spec?.memoryGiB == 8)
+}
+
 // MARK: - Service state transitions
 
 @MainActor


### PR DESCRIPTION
## What does this PR do?

Adds CPU and memory allocation to the container Run and Edit forms. Previously every container silently got the runtime defaults (4 CPUs, 1 GB) with no way to change them in the GUI, which is what #73 asks for.

Changes:

- **`ContainerRunConfig`**: new `cpus` / `memoryGiB` fields defaulting to the runtime's own values (4 CPUs, 1 GB), so an untouched form creates exactly the same container as before
- **`ContainerConfigForm`**: a Resources section on the Basic tab using the same `NumericStepperField` idiom and host-capacity clamping as the machine forms
- **`ContainerCreateSpec` / `LiveContainerBackend`**: the values are applied to `containerConfig.resources` at create time
- **`EditContainerView`**: prefills from the container's actual `resources`, so RAM and CPU can be changed after creation via the existing stop/recreate flow
- **Recovery**: auto-recreated containers now preserve their resources; previously recovery silently reverted them to defaults (a latent bug this change would otherwise have surfaced)
- 2 new tests covering default and configured passthrough to the create spec

## Related issues

Closes #73

## Screenshots / recording

New Resources section (CPUs and Memory steppers) on the Basic tab of the Run/Edit container forms, matching the machine create form's controls.

## Checklist

- [x] The project builds and runs (`Orchard` scheme)
- [x] Tests pass (`⌘U` / `xcodebuild test`) - 198/198
- [x] I've added an entry to `CHANGELOG.md` (Added / Changed / Fixed)
- [x] The change is focused on a single logical concern
