### PR TITLE
Detect oMLX model servers in the AI Models section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-<<<<<<< HEAD
 - Containers can now be created with a chosen CPU and memory allocation, and both can be changed later from Edit Configuration (via the usual stop/recreate flow). Previously every container silently got the runtime defaults of 4 CPUs and 1 GB with no way to change them in the GUI ([#73](https://github.com/andrew-waters/orchard/issues/73)).
-=======
 - The AI Models section now recognises [oMLX](https://github.com/jundot/omlx) servers. oMLX serves the same OpenAI-style API on the same conventional port (8000) as `mlx_lm.server`, so it previously appeared as a generic "MLX Server"; it's now identified by the `owned_by: omlx` stamp in its models listing ([#72](https://github.com/andrew-waters/orchard/issues/72)).
->>>>>>> 7654b82 (Detect oMLX model servers in the AI Models section)
 
 ### Fixed
 - Unchecking "Run in detached mode (background)" now does what it says: after the container starts, Orchard opens your preferred terminal attached to it. The toggle no longer appears in the Edit Configuration sheet, where recreation always happens in the background ([#43](https://github.com/andrew-waters/orchard/issues/43)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+<<<<<<< HEAD
 - Containers can now be created with a chosen CPU and memory allocation, and both can be changed later from Edit Configuration (via the usual stop/recreate flow). Previously every container silently got the runtime defaults of 4 CPUs and 1 GB with no way to change them in the GUI ([#73](https://github.com/andrew-waters/orchard/issues/73)).
+=======
+- The AI Models section now recognises [oMLX](https://github.com/jundot/omlx) servers. oMLX serves the same OpenAI-style API on the same conventional port (8000) as `mlx_lm.server`, so it previously appeared as a generic "MLX Server"; it's now identified by the `owned_by: omlx` stamp in its models listing ([#72](https://github.com/andrew-waters/orchard/issues/72)).
+>>>>>>> 7654b82 (Detect oMLX model servers in the AI Models section)
 
 ### Fixed
 - Unchecking "Run in detached mode (background)" now does what it says: after the container starts, Orchard opens your preferred terminal attached to it. The toggle no longer appears in the Edit Configuration sheet, where recreation always happens in the background ([#43](https://github.com/andrew-waters/orchard/issues/43)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Containers can now be created with a chosen CPU and memory allocation, and both can be changed later from Edit Configuration (via the usual stop/recreate flow). Previously every container silently got the runtime defaults of 4 CPUs and 1 GB with no way to change them in the GUI ([#73](https://github.com/andrew-waters/orchard/issues/73)).
 - The AI Models section now recognises [oMLX](https://github.com/jundot/omlx) servers. oMLX serves the same OpenAI-style API on the same conventional port (8000) as `mlx_lm.server`, so it previously appeared as a generic "MLX Server"; it's now identified by the `owned_by: omlx` stamp in its models listing ([#72](https://github.com/andrew-waters/orchard/issues/72)).
+- Local model servers that require an API key (oMLX generates one at setup) are no longer invisible: they appear as a locked provider with a field to paste the key, which is then used for detection, model listing, the chat tester, and the container bridge (`OPENAI_API_KEY`).
 
 ### Fixed
 - Unchecking "Run in detached mode (background)" now does what it says: after the container starts, Orchard opens your preferred terminal attached to it. The toggle no longer appears in the Edit Configuration sheet, where recreation always happens in the background ([#43](https://github.com/andrew-waters/orchard/issues/43)).

--- a/Orchard/Models.swift
+++ b/Orchard/Models.swift
@@ -318,6 +318,7 @@ struct ModelProvider: Identifiable, Equatable, Sendable {
         case ollama
         case lmStudio
         case mlxServer
+        case omlx
         case custom
 
         var displayName: String {
@@ -325,6 +326,7 @@ struct ModelProvider: Identifiable, Equatable, Sendable {
             case .ollama: return "Ollama"
             case .lmStudio: return "LM Studio"
             case .mlxServer: return "MLX Server"
+            case .omlx: return "oMLX"
             case .custom: return "Custom"
             }
         }

--- a/Orchard/Models.swift
+++ b/Orchard/Models.swift
@@ -339,6 +339,9 @@ struct ModelProvider: Identifiable, Equatable, Sendable {
     let api: ModelAPIStyle
     /// Model identifiers the provider advertises, when it exposes a listing endpoint.
     var models: [String]
+    /// The server answered the probe with 401/403: it's running but wants an API key
+    /// before it will list models or serve completions.
+    var requiresAPIKey: Bool = false
 
     /// Stable across refreshes: only one server can listen on a port, and `api` comes
     /// from the probe's static candidate rather than response data - so `kind` being

--- a/Orchard/Models.swift
+++ b/Orchard/Models.swift
@@ -340,8 +340,11 @@ struct ModelProvider: Identifiable, Equatable, Sendable {
     /// Model identifiers the provider advertises, when it exposes a listing endpoint.
     var models: [String]
 
-    /// Stable across refreshes: a provider is identified by its kind and port.
-    var id: String { "\(kind.rawValue):\(port)" }
+    /// Stable across refreshes: only one server can listen on a port, and `api` comes
+    /// from the probe's static candidate rather than response data - so `kind` being
+    /// refined from the models listing (e.g. oMLX) can't flap identity-based UI state
+    /// if a listing is transiently missing or malformed.
+    var id: String { "\(api.rawValue):\(port)" }
 
     /// The base URL reachable *from the host* (e.g. `http://127.0.0.1:11434`). Distinct
     /// from the container-reachable URL, which goes through the network gateway - see

--- a/Orchard/Services/AppServices.swift
+++ b/Orchard/Services/AppServices.swift
@@ -45,11 +45,12 @@ final class AppServices: ObservableObject {
         modelBackend: ModelBackend = LiveModelBackend(),
         modelServerEngine: ModelServerEngine = MLXServerEngine(),
         runner: CommandRunner = SystemCommandRunner(),
-        defaults: UserDefaults = .standard
+        defaults: UserDefaults = .standard,
+        secrets: SecretsStore = KeychainSecretsStore()
     ) {
         let alertCenter = AlertCenter()
         self.alertCenter = alertCenter
-        let settings = SettingsStore(alertCenter: alertCenter, defaults: defaults)
+        let settings = SettingsStore(alertCenter: alertCenter, defaults: defaults, secrets: secrets)
         self.settings = settings
         self.terminalLauncher = TerminalLauncher(settings: settings, alertCenter: alertCenter)
         let builderService = BuilderService(runner: runner, settings: settings, alertCenter: alertCenter)

--- a/Orchard/Services/AppServices.swift
+++ b/Orchard/Services/AppServices.swift
@@ -68,7 +68,7 @@ final class AppServices: ObservableObject {
         let statsService = StatsService(backend: backend, alertCenter: alertCenter, containerList: containerListService)
         self.statsService = statsService
         self.machineService = MachineService(backend: machineBackend, alertCenter: alertCenter)
-        self.modelService = ModelService(backend: modelBackend)
+        self.modelService = ModelService(backend: modelBackend, settings: settings)
         self.modelServerService = ModelServerService(engine: modelServerEngine, alertCenter: alertCenter)
 
         containerListService.reloadBuilders = { [weak builderService] in await builderService?.loadBuilders() }

--- a/Orchard/Services/ModelBackend.swift
+++ b/Orchard/Services/ModelBackend.swift
@@ -109,11 +109,26 @@ struct LiveModelBackend: ModelBackend {
             return nil
         }
         return ModelProvider(
-            kind: candidate.kind,
+            kind: refineKind(candidate.kind, data: data, api: candidate.api),
             port: candidate.port,
             api: candidate.api,
             models: parseModels(data, api: candidate.api)
         )
+    }
+
+    /// oMLX serves the same OpenAI-style API on the same conventional port (8000) as
+    /// `mlx_lm.server`, so the port alone can't tell them apart. Its models listing
+    /// stamps `"owned_by": "omlx"` on every model - that's the fingerprint used here.
+    static func refineKind(_ kind: ModelProvider.Kind, data: Data, api: ModelAPIStyle) -> ModelProvider.Kind {
+        guard api == .openAI,
+              let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let models = obj["data"] as? [[String: Any]] else {
+            return kind
+        }
+        if models.contains(where: { ($0["owned_by"] as? String) == "omlx" }) {
+            return .omlx
+        }
+        return kind
     }
 
     func complete(port: UInt16, api: ModelAPIStyle, model: String, messages: [ChatMessage]) async throws -> String {

--- a/Orchard/Services/ModelBackend.swift
+++ b/Orchard/Services/ModelBackend.swift
@@ -27,12 +27,14 @@ enum ModelBridge {
     /// Environment variables (as `key`/`value` pairs) to inject into a container so a
     /// standard client inside it reaches the host provider at `baseURL`. The placeholder
     /// key satisfies SDKs that require one even though a local server ignores it.
-    static func injectionEnvironment(baseURL: String, api: ModelAPIStyle) -> [(key: String, value: String)] {
+    static func injectionEnvironment(baseURL: String, api: ModelAPIStyle, apiKey: String? = nil) -> [(key: String, value: String)] {
         switch api {
         case .openAI:
             return [
                 ("OPENAI_BASE_URL", baseURL),
-                ("OPENAI_API_KEY", "not-needed"),
+                // A keyed server (e.g. oMLX with auth enabled) needs the real key;
+                // an open one just needs the placeholder SDKs insist on.
+                ("OPENAI_API_KEY", apiKey ?? "not-needed"),
             ]
         case .ollama:
             return [
@@ -49,13 +51,14 @@ enum ModelBridge {
 /// app-owned types only, so mocks need no package imports.
 protocol ModelBackend: Sendable {
     /// Probe the host for running model providers and return those that responded.
+    /// `apiKeys` maps port -> stored API key, sent as a bearer token where present.
     /// Best-effort: never throws, since a missing provider is a normal state.
-    func detectProviders() async -> [ModelProvider]
+    func detectProviders(apiKeys: [UInt16: String]) async -> [ModelProvider]
 
     /// Send a chat conversation to a provider on the host (`127.0.0.1:port`) and return the
     /// assistant's reply. `messages` is the full history so the model has context. Used by
     /// the in-app tester; throws on transport or HTTP errors so the UI can surface them.
-    func complete(port: UInt16, api: ModelAPIStyle, model: String, messages: [ChatMessage]) async throws -> String
+    func complete(port: UInt16, api: ModelAPIStyle, model: String, messages: [ChatMessage], apiKey: String?) async throws -> String
 }
 
 // MARK: - Live implementation
@@ -86,11 +89,12 @@ struct LiveModelBackend: ModelBackend {
         self.session = session
     }
 
-    func detectProviders() async -> [ModelProvider] {
+    func detectProviders(apiKeys: [UInt16: String]) async -> [ModelProvider] {
         let session = self.session
         return await withTaskGroup(of: ModelProvider?.self) { group in
             for candidate in Self.candidates {
-                group.addTask { await Self.probe(candidate, session: session) }
+                let key = apiKeys[candidate.port]
+                group.addTask { await Self.probe(candidate, session: session, apiKey: key) }
             }
             var found: [ModelProvider] = []
             for await result in group {
@@ -100,20 +104,44 @@ struct LiveModelBackend: ModelBackend {
         }
     }
 
-    private static func probe(_ candidate: Candidate, session: URLSession) async -> ModelProvider? {
+    private static func probe(_ candidate: Candidate, session: URLSession, apiKey: String?) async -> ModelProvider? {
         guard let url = URL(string: "http://127.0.0.1:\(candidate.port)\(candidate.listPath)") else { return nil }
         var request = URLRequest(url: url)
         request.timeoutInterval = 1.5
+        if let apiKey {
+            request.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
+        }
         guard let (data, response) = try? await session.data(for: request),
-              let http = response as? HTTPURLResponse, http.statusCode == 200 else {
+              let http = response as? HTTPURLResponse else {
             return nil
         }
-        return ModelProvider(
-            kind: refineKind(candidate.kind, data: data, api: candidate.api),
-            port: candidate.port,
-            api: candidate.api,
-            models: parseModels(data, api: candidate.api)
-        )
+        return provider(from: http.statusCode, data: data, candidate: candidate)
+    }
+
+    /// Classify a probe response. 200 is a live provider; 401/403 is a live server that
+    /// wants an API key (e.g. oMLX generates one at setup) - surfaced as locked so the
+    /// user can supply the key, rather than being invisible. Anything else is not a
+    /// provider. Pure, so the classification is unit-testable.
+    static func provider(from status: Int, data: Data, candidate: Candidate) -> ModelProvider? {
+        switch status {
+        case 200:
+            return ModelProvider(
+                kind: refineKind(candidate.kind, data: data, api: candidate.api),
+                port: candidate.port,
+                api: candidate.api,
+                models: parseModels(data, api: candidate.api)
+            )
+        case 401, 403:
+            return ModelProvider(
+                kind: candidate.kind,
+                port: candidate.port,
+                api: candidate.api,
+                models: [],
+                requiresAPIKey: true
+            )
+        default:
+            return nil
+        }
     }
 
     /// oMLX serves the same OpenAI-style API on the same conventional port (8000) as
@@ -131,7 +159,7 @@ struct LiveModelBackend: ModelBackend {
         return kind
     }
 
-    func complete(port: UInt16, api: ModelAPIStyle, model: String, messages: [ChatMessage]) async throws -> String {
+    func complete(port: UInt16, api: ModelAPIStyle, model: String, messages: [ChatMessage], apiKey: String?) async throws -> String {
         let root = "http://127.0.0.1:\(port)"
         let wireMessages = messages.map { ["role": $0.role.rawValue, "content": $0.content] }
         let path: String
@@ -160,6 +188,9 @@ struct LiveModelBackend: ModelBackend {
         var request = URLRequest(url: url)
         request.httpMethod = "POST"
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        if let apiKey {
+            request.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
+        }
         request.httpBody = try JSONSerialization.data(withJSONObject: body)
         request.timeoutInterval = 120
 

--- a/Orchard/Services/ModelService.swift
+++ b/Orchard/Services/ModelService.swift
@@ -11,14 +11,16 @@ final class ModelService: ObservableObject {
     @Published var isLoading = false
 
     private let backend: ModelBackend
+    private let settings: SettingsStore
 
-    init(backend: ModelBackend) {
+    init(backend: ModelBackend, settings: SettingsStore) {
         self.backend = backend
+        self.settings = settings
     }
 
     func load(showLoading: Bool = true) async {
         if showLoading { isLoading = true }
-        let providers = await backend.detectProviders()
+        let providers = await backend.detectProviders(apiKeys: settings.allModelAPIKeys())
         if providers != self.providers {
             self.providers = providers
         }
@@ -28,7 +30,14 @@ final class ModelService: ObservableObject {
     /// Send a chat conversation to a provider running on the host and return its reply.
     /// Surfaces transport/HTTP errors to the caller (the tester shows them inline).
     func complete(port: UInt16, api: ModelAPIStyle, model: String, messages: [ChatMessage]) async throws -> String {
-        try await backend.complete(port: port, api: api, model: model, messages: messages)
+        try await backend.complete(port: port, api: api, model: model, messages: messages, apiKey: settings.modelAPIKey(port: port))
+    }
+
+    /// Store (or clear, when empty) the API key for the server on `port`, then re-detect
+    /// so a locked provider unlocks immediately.
+    func setAPIKey(_ key: String, port: UInt16) async {
+        settings.setModelAPIKey(key, port: port)
+        await load(showLoading: false)
     }
 
     /// The environment-variable pairs to inject so a container attached to `network`
@@ -37,6 +46,6 @@ final class ModelService: ObservableObject {
     func bridgeEnvironment(for provider: ModelProvider, on network: ContainerNetwork) -> [(key: String, value: String)]? {
         guard let gateway = network.status.gateway, !gateway.isEmpty else { return nil }
         let baseURL = ModelBridge.containerBaseURL(gateway: gateway, hostPort: provider.port, api: provider.api)
-        return ModelBridge.injectionEnvironment(baseURL: baseURL, api: provider.api)
+        return ModelBridge.injectionEnvironment(baseURL: baseURL, api: provider.api, apiKey: settings.modelAPIKey(port: provider.port))
     }
 }

--- a/Orchard/Services/SecretsStore.swift
+++ b/Orchard/Services/SecretsStore.swift
@@ -1,0 +1,93 @@
+import Foundation
+import Security
+
+/// Minimal secret storage keyed by an account string. Production uses the keychain so
+/// credentials never sit in UserDefaults; tests inject the in-memory variant so they
+/// never touch the real keychain.
+protocol SecretsStore: Sendable {
+    func secret(for account: String) -> String?
+    /// nil or empty removes the stored secret.
+    func setSecret(_ value: String?, for account: String)
+    func allSecrets() -> [String: String]
+}
+
+/// Generic-password keychain items under a single service name, one item per account.
+struct KeychainSecretsStore: SecretsStore {
+    let service: String
+
+    init(service: String = "dev.andon.orchard.model-api-keys") {
+        self.service = service
+    }
+
+    func secret(for account: String) -> String? {
+        var query = baseQuery(account: account)
+        query[kSecReturnData as String] = true
+        query[kSecMatchLimit as String] = kSecMatchLimitOne
+        var item: CFTypeRef?
+        guard SecItemCopyMatching(query as CFDictionary, &item) == errSecSuccess,
+              let data = item as? Data else { return nil }
+        return String(data: data, encoding: .utf8)
+    }
+
+    func setSecret(_ value: String?, for account: String) {
+        SecItemDelete(baseQuery(account: account) as CFDictionary)
+        guard let value, !value.isEmpty else { return }
+        var add = baseQuery(account: account)
+        add[kSecValueData as String] = Data(value.utf8)
+        SecItemAdd(add as CFDictionary, nil)
+    }
+
+    func allSecrets() -> [String: String] {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecMatchLimit as String: kSecMatchLimitAll,
+            kSecReturnAttributes as String: true,
+            kSecReturnData as String: true,
+        ]
+        var items: CFTypeRef?
+        guard SecItemCopyMatching(query as CFDictionary, &items) == errSecSuccess,
+              let attributeList = items as? [[String: Any]] else { return [:] }
+        var result: [String: String] = [:]
+        for attributes in attributeList {
+            if let account = attributes[kSecAttrAccount as String] as? String,
+               let data = attributes[kSecValueData as String] as? Data,
+               let value = String(data: data, encoding: .utf8) {
+                result[account] = value
+            }
+        }
+        return result
+    }
+
+    private func baseQuery(account: String) -> [String: Any] {
+        [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: account,
+        ]
+    }
+}
+
+/// Test double: a locked dictionary, no keychain involvement.
+final class InMemorySecretsStore: SecretsStore, @unchecked Sendable {
+    private var storage: [String: String] = [:]
+    private let lock = NSLock()
+
+    func secret(for account: String) -> String? {
+        lock.withLock { storage[account] }
+    }
+
+    func setSecret(_ value: String?, for account: String) {
+        lock.withLock {
+            if let value, !value.isEmpty {
+                storage[account] = value
+            } else {
+                storage.removeValue(forKey: account)
+            }
+        }
+    }
+
+    func allSecrets() -> [String: String] {
+        lock.withLock { storage }
+    }
+}

--- a/Orchard/Services/SettingsStore.swift
+++ b/Orchard/Services/SettingsStore.swift
@@ -140,4 +140,38 @@ final class SettingsStore: ObservableObject {
             return defaultBinaryPath
         }
     }
+
+    // MARK: - Model provider API keys
+
+    /// Per-port API keys for local model servers (e.g. an oMLX install that generated
+    /// one at setup). Keyed by port because that's the only stable identity a detected
+    /// provider has. Stored in UserDefaults - these guard loopback-only servers, so the
+    /// keychain's ceremony isn't warranted.
+    private let modelAPIKeysKey = "ModelProviderAPIKeys"
+
+    func modelAPIKey(port: UInt16) -> String? {
+        let keys = defaults.dictionary(forKey: modelAPIKeysKey) as? [String: String]
+        return keys?[String(port)]
+    }
+
+    func setModelAPIKey(_ key: String?, port: UInt16) {
+        var keys = (defaults.dictionary(forKey: modelAPIKeysKey) as? [String: String]) ?? [:]
+        if let key, !key.isEmpty {
+            keys[String(port)] = key
+        } else {
+            keys.removeValue(forKey: String(port))
+        }
+        defaults.set(keys, forKey: modelAPIKeysKey)
+        objectWillChange.send()
+    }
+
+    /// All stored provider keys, for the detection probe.
+    func allModelAPIKeys() -> [UInt16: String] {
+        let keys = (defaults.dictionary(forKey: modelAPIKeysKey) as? [String: String]) ?? [:]
+        var result: [UInt16: String] = [:]
+        for (portString, key) in keys {
+            if let port = UInt16(portString) { result[port] = key }
+        }
+        return result
+    }
 }

--- a/Orchard/Services/SettingsStore.swift
+++ b/Orchard/Services/SettingsStore.swift
@@ -12,6 +12,9 @@ final class SettingsStore: ObservableObject {
     /// Backing store for persisted settings. Production uses `.standard`; tests inject an
     /// ephemeral suite so they never read or mutate the real user domain.
     private let defaults: UserDefaults
+    /// Credential storage for model-server API keys. Keychain in production; tests
+    /// inject the in-memory variant.
+    private let secrets: SecretsStore
 
     private let fallbackBinaryPath = "/usr/local/bin/container"
     private let candidateBinaryPaths: [String] = [
@@ -42,7 +45,8 @@ final class SettingsStore: ObservableObject {
         return customPath != defaultBinaryPath && validateBinaryPath(customPath)
     }
 
-    init(alertCenter: AlertCenter, defaults: UserDefaults = .standard) {
+    init(alertCenter: AlertCenter, defaults: UserDefaults = .standard, secrets: SecretsStore = KeychainSecretsStore()) {
+        self.secrets = secrets
         self.alertCenter = alertCenter
         self.defaults = defaults
         loadCustomBinaryPath()
@@ -145,31 +149,21 @@ final class SettingsStore: ObservableObject {
 
     /// Per-port API keys for local model servers (e.g. an oMLX install that generated
     /// one at setup). Keyed by port because that's the only stable identity a detected
-    /// provider has. Stored in UserDefaults - these guard loopback-only servers, so the
-    /// keychain's ceremony isn't warranted.
-    private let modelAPIKeysKey = "ModelProviderAPIKeys"
-
+    /// provider has. Stored in the keychain, not UserDefaults - they're credentials,
+    /// and the bridge injects them into containers that may be internet-enabled.
     func modelAPIKey(port: UInt16) -> String? {
-        let keys = defaults.dictionary(forKey: modelAPIKeysKey) as? [String: String]
-        return keys?[String(port)]
+        secrets.secret(for: String(port))
     }
 
     func setModelAPIKey(_ key: String?, port: UInt16) {
-        var keys = (defaults.dictionary(forKey: modelAPIKeysKey) as? [String: String]) ?? [:]
-        if let key, !key.isEmpty {
-            keys[String(port)] = key
-        } else {
-            keys.removeValue(forKey: String(port))
-        }
-        defaults.set(keys, forKey: modelAPIKeysKey)
+        secrets.setSecret(key, for: String(port))
         objectWillChange.send()
     }
 
     /// All stored provider keys, for the detection probe.
     func allModelAPIKeys() -> [UInt16: String] {
-        let keys = (defaults.dictionary(forKey: modelAPIKeysKey) as? [String: String]) ?? [:]
         var result: [UInt16: String] = [:]
-        for (portString, key) in keys {
+        for (portString, key) in secrets.allSecrets() {
             if let port = UInt16(portString) { result[port] = key }
         }
         return result

--- a/Orchard/Services/UITestSupport.swift
+++ b/Orchard/Services/UITestSupport.swift
@@ -143,11 +143,11 @@ struct UITestMachineBackend: MachineBackend {
 /// A `ModelBackend` returning a single fixed provider. Debug-only; activated solely by the
 /// launch argument, so the model-bridge UI renders in the smoke suite without a live server.
 struct UITestModelBackend: ModelBackend {
-    func detectProviders() async -> [ModelProvider] {
+    func detectProviders(apiKeys: [UInt16: String]) async -> [ModelProvider] {
         [ModelProvider(kind: .mlxServer, port: 8080, api: .openAI, models: ["mlx-community/Llama-3.2-1B-Instruct-4bit"])]
     }
 
-    func complete(port: UInt16, api: ModelAPIStyle, model: String, messages: [ChatMessage]) async throws -> String {
+    func complete(port: UInt16, api: ModelAPIStyle, model: String, messages: [ChatMessage], apiKey: String?) async throws -> String {
         "This is a canned UI-test reply to: \(messages.last?.content ?? "")"
     }
 }

--- a/Orchard/Views/Features/Models/ModelsView.swift
+++ b/Orchard/Views/Features/Models/ModelsView.swift
@@ -119,6 +119,8 @@ struct ModelDetailView: View {
 
     @State private var runTarget: RunTarget?
     @State private var testTarget: TestTarget?
+    /// Draft key for unlocking a 401-locked provider; cleared on save.
+    @State private var apiKeyDraft = ""
 
     private struct RunTarget: Identifiable {
         let id = UUID(); let modelID: String
@@ -224,7 +226,27 @@ struct ModelDetailView: View {
                     .foregroundColor(.secondary)
             }
 
-            if provider.models.isEmpty {
+            if provider.requiresAPIKey {
+                VStack(alignment: .leading, spacing: 8) {
+                    Label("API key required", systemImage: "lock")
+                        .font(.caption)
+                        .foregroundColor(.orange)
+                    Text("This server rejected the probe with 401. Paste its API key to list models and chat.")
+                        .font(.caption2)
+                        .foregroundColor(.secondary)
+                    HStack(spacing: 8) {
+                        SecureField("API key", text: $apiKeyDraft)
+                            .textFieldStyle(.roundedBorder)
+                            .frame(maxWidth: 280)
+                        Button("Save") {
+                            let key = apiKeyDraft
+                            apiKeyDraft = ""
+                            Task { await modelService.setAPIKey(key, port: provider.port) }
+                        }
+                        .disabled(apiKeyDraft.isEmpty)
+                    }
+                }
+            } else if provider.models.isEmpty {
                 Text("No models reported").font(.caption).foregroundColor(.secondary)
             } else {
                 VStack(alignment: .leading, spacing: 4) {
@@ -235,15 +257,17 @@ struct ModelDetailView: View {
                 }
             }
 
-            HStack(spacing: 8) {
-                Button(action: { testTarget = TestTarget(name: provider.kind.displayName, port: provider.port, api: provider.api, model: provider.models.first ?? "") }) {
-                    Label("Chat…", systemImage: "text.bubble")
+            if !provider.requiresAPIKey {
+                HStack(spacing: 8) {
+                    Button(action: { testTarget = TestTarget(name: provider.kind.displayName, port: provider.port, api: provider.api, model: provider.models.first ?? "") }) {
+                        Label("Chat…", systemImage: "text.bubble")
+                    }
+                    Button(action: { runTarget = RunTarget(modelID: provider.id) }) {
+                        Label("New sandbox…", systemImage: "shield.lefthalf.filled")
+                    }
                 }
-                Button(action: { runTarget = RunTarget(modelID: provider.id) }) {
-                    Label("New sandbox…", systemImage: "shield.lefthalf.filled")
-                }
+                .font(.subheadline)
             }
-            .font(.subheadline)
 
             Spacer()
         }

--- a/Orchard/Views/Features/Models/ModelsView.swift
+++ b/Orchard/Views/Features/Models/ModelsView.swift
@@ -231,7 +231,7 @@ struct ModelDetailView: View {
                     Label("API key required", systemImage: "lock")
                         .font(.caption)
                         .foregroundColor(.orange)
-                    Text("This server rejected the probe with 401. Paste its API key to list models and chat.")
+                    Text("This server rejected the probe with 401 or 403. Paste its API key to list models and chat.")
                         .font(.caption2)
                         .foregroundColor(.secondary)
                     HStack(spacing: 8) {

--- a/Orchard/Views/Features/Models/RunModelContainer.swift
+++ b/Orchard/Views/Features/Models/RunModelContainer.swift
@@ -10,6 +10,7 @@ struct RunModelContainerView: View {
     @EnvironmentObject var networkService: NetworkService
     @EnvironmentObject var modelService: ModelService
     @EnvironmentObject var modelServerService: ModelServerService
+    @EnvironmentObject var settings: SettingsStore
     @Environment(\.dismiss) private var dismiss
 
     /// A model id (managed server or detected provider) to preselect, or nil to let the user
@@ -253,7 +254,7 @@ struct RunModelContainerView: View {
 
     private func run() {
         guard let baseURL, let target else { return }
-        let env = ModelBridge.injectionEnvironment(baseURL: baseURL, api: target.api)
+        let env = ModelBridge.injectionEnvironment(baseURL: baseURL, api: target.api, apiKey: settings.modelAPIKey(port: target.port))
             .map { ContainerRunConfig.EnvironmentVariable(key: $0.key, value: $0.value) }
 
         let config = ContainerRunConfig(

--- a/Orchard/Views/Features/Models/RunModelContainer.swift
+++ b/Orchard/Views/Features/Models/RunModelContainer.swift
@@ -43,7 +43,9 @@ struct RunModelContainerView: View {
         }
         let managedPorts = modelServerService.managedPorts
         let providers = modelService.providers
-            .filter { !managedPorts.contains($0.port) }
+            // A locked provider has no usable key yet - a sandbox wired to it could
+            // never reach its model, so it isn't offered as a target.
+            .filter { !managedPorts.contains($0.port) && !$0.requiresAPIKey }
             .map { Target(id: $0.id, name: $0.kind.displayName, port: $0.port, api: $0.api) }
         return servers + providers
     }

--- a/OrchardTests/Mocks.swift
+++ b/OrchardTests/Mocks.swift
@@ -391,6 +391,7 @@ final class MockModelBackend: ModelBackend, @unchecked Sendable {
     private let lock = NSLock()
     private var _providers: [ModelProvider]
     private var _detectCount = 0
+    private var _lastAPIKeys: [UInt16: String] = [:]
 
     init(providers: [ModelProvider] = []) {
         self._providers = providers
@@ -419,14 +420,17 @@ final class MockModelBackend: ModelBackend, @unchecked Sendable {
     }
     var completeMessageCounts: [Int] { lock.withLock { _completeMessageCounts } }
 
-    func detectProviders() async -> [ModelProvider] {
+    func detectProviders(apiKeys: [UInt16: String]) async -> [ModelProvider] {
         lock.withLock {
             _detectCount += 1
+            _lastAPIKeys = apiKeys
             return _providers
         }
     }
 
-    func complete(port: UInt16, api: ModelAPIStyle, model: String, messages: [ChatMessage]) async throws -> String {
+    var lastAPIKeys: [UInt16: String] { lock.withLock { _lastAPIKeys } }
+
+    func complete(port: UInt16, api: ModelAPIStyle, model: String, messages: [ChatMessage], apiKey: String?) async throws -> String {
         try lock.withLock {
             _completeMessageCounts.append(messages.count)
             if let _completeError { throw _completeError }

--- a/OrchardTests/Mocks.swift
+++ b/OrchardTests/Mocks.swift
@@ -316,7 +316,7 @@ func makeService(
     runner: MockCommandRunner = MockCommandRunner(),
     defaults: UserDefaults = ephemeralDefaults()
 ) -> AppServices {
-    AppServices(backend: backend, runner: runner, defaults: defaults)
+    AppServices(backend: backend, runner: runner, defaults: defaults, secrets: InMemorySecretsStore())
 }
 
 /// A throwaway `UserDefaults` suite, unique per call, so a service built in a test never

--- a/OrchardTests/ModelBridgeTests.swift
+++ b/OrchardTests/ModelBridgeTests.swift
@@ -50,6 +50,26 @@ func parseOllamaModels() {
     #expect(LiveModelBackend.parseModels(json, api: .ollama) == ["llama3.1:latest", "mistral:7b"])
 }
 
+@Test("Refine: an oMLX models listing (owned_by \"omlx\") reclassifies the provider")
+func refineKindOMLX() {
+    let json = Data(#"{"object":"list","data":[{"id":"llama-3.2-1b","owned_by":"omlx"}]}"#.utf8)
+    #expect(LiveModelBackend.refineKind(.mlxServer, data: json, api: .openAI) == .omlx)
+}
+
+@Test("Refine: other owned_by values and non-OpenAI APIs keep the candidate's kind")
+func refineKindPassthrough() {
+    let mlx = Data(#"{"object":"list","data":[{"id":"llama-3.2-1b","owned_by":"mlx"}]}"#.utf8)
+    #expect(LiveModelBackend.refineKind(.mlxServer, data: mlx, api: .openAI) == .mlxServer)
+
+    let noOwner = Data(#"{"object":"list","data":[{"id":"llama-3.2-1b"}]}"#.utf8)
+    #expect(LiveModelBackend.refineKind(.lmStudio, data: noOwner, api: .openAI) == .lmStudio)
+
+    let ollama = Data(#"{"models":[{"name":"llama3.1:latest"}]}"#.utf8)
+    #expect(LiveModelBackend.refineKind(.ollama, data: ollama, api: .ollama) == .ollama)
+
+    #expect(LiveModelBackend.refineKind(.mlxServer, data: Data("not json".utf8), api: .openAI) == .mlxServer)
+}
+
 @Test("Parse: malformed or empty JSON yields no models rather than throwing")
 func parseGarbage() {
     #expect(LiveModelBackend.parseModels(Data("not json".utf8), api: .openAI).isEmpty)

--- a/OrchardTests/ModelBridgeTests.swift
+++ b/OrchardTests/ModelBridgeTests.swift
@@ -96,3 +96,39 @@ func parseCompletionBadShape() {
         try LiveModelBackend.parseCompletion(Data("{}".utf8), api: .openAI)
     }
 }
+
+// MARK: - Probe classification and API keys (#72 follow-up)
+
+private let omlxCandidate = LiveModelBackend.Candidate(kind: .mlxServer, port: 8000, api: .openAI, listPath: "/v1/models")
+
+@Test("Probe: a 200 with an oMLX listing yields an unlocked oMLX provider")
+func probeClassifiesOK() {
+    let json = Data(#"{"object":"list","data":[{"id":"qwen3-4b","owned_by":"omlx"}]}"#.utf8)
+    let provider = LiveModelBackend.provider(from: 200, data: json, candidate: omlxCandidate)
+    #expect(provider?.kind == .omlx)
+    #expect(provider?.models == ["qwen3-4b"])
+    #expect(provider?.requiresAPIKey == false)
+}
+
+@Test("Probe: 401 and 403 surface a locked provider instead of hiding the server", arguments: [401, 403])
+func probeClassifiesLocked(status: Int) {
+    let errorBody = Data(#"{"error":{"message":"API key required"}}"#.utf8)
+    let provider = LiveModelBackend.provider(from: status, data: errorBody, candidate: omlxCandidate)
+    #expect(provider?.requiresAPIKey == true)
+    #expect(provider?.models.isEmpty == true)
+    #expect(provider?.kind == .mlxServer)   // can't refine without a listing
+}
+
+@Test("Probe: other statuses are not a provider", arguments: [404, 500, 302])
+func probeClassifiesOther(status: Int) {
+    #expect(LiveModelBackend.provider(from: status, data: Data(), candidate: omlxCandidate) == nil)
+}
+
+@Test("Bridge env: a stored API key replaces the placeholder")
+func bridgeEnvWithKey() {
+    let env = ModelBridge.injectionEnvironment(baseURL: "http://192.168.64.1:8000/v1", api: .openAI, apiKey: "sk-test")
+    #expect(env.contains { $0.key == "OPENAI_API_KEY" && $0.value == "sk-test" })
+
+    let open = ModelBridge.injectionEnvironment(baseURL: "http://192.168.64.1:8000/v1", api: .openAI)
+    #expect(open.contains { $0.key == "OPENAI_API_KEY" && $0.value == "not-needed" })
+}

--- a/OrchardTests/ModelServiceTests.swift
+++ b/OrchardTests/ModelServiceTests.swift
@@ -23,13 +23,19 @@ private func makeNetwork(id: String = "default", gateway: String? = "192.168.66.
     )
 }
 
+
+@MainActor
+private func makeModelService(backend: ModelBackend) -> ModelService {
+    ModelService(backend: backend, settings: SettingsStore(alertCenter: AlertCenter(), defaults: ephemeralDefaults()))
+}
+
 // MARK: - load
 
 @Test("Models load: publishes detected providers and clears loading")
 @MainActor
 func modelsLoadSuccess() async {
     let backend = MockModelBackend(providers: [makeProvider()])
-    let service = ModelService(backend: backend)
+    let service = makeModelService(backend: backend)
 
     await service.load()
 
@@ -42,7 +48,7 @@ func modelsLoadSuccess() async {
 @Test("Models load: no providers running publishes an empty list, not an error")
 @MainActor
 func modelsLoadEmpty() async {
-    let service = ModelService(backend: MockModelBackend(providers: []))
+    let service = makeModelService(backend: MockModelBackend(providers: []))
 
     await service.load()
 
@@ -55,7 +61,7 @@ func modelsLoadEmpty() async {
 @Test("Bridge env: resolves the network gateway into an OpenAI base URL")
 @MainActor
 func bridgeEnvResolvesGateway() {
-    let service = ModelService(backend: MockModelBackend())
+    let service = makeModelService(backend: MockModelBackend())
     let env = service.bridgeEnvironment(for: makeProvider(port: 8080, api: .openAI), on: makeNetwork(gateway: "192.168.66.1"))
 
     #expect(env?.first { $0.key == "OPENAI_BASE_URL" }?.value == "http://192.168.66.1:8080/v1")
@@ -64,7 +70,7 @@ func bridgeEnvResolvesGateway() {
 @Test("Bridge env: a network without a gateway yields nil (no route to host)")
 @MainActor
 func bridgeEnvNoGateway() {
-    let service = ModelService(backend: MockModelBackend())
+    let service = makeModelService(backend: MockModelBackend())
 
     #expect(service.bridgeEnvironment(for: makeProvider(), on: makeNetwork(gateway: nil)) == nil)
     #expect(service.bridgeEnvironment(for: makeProvider(), on: makeNetwork(gateway: "")) == nil)

--- a/OrchardTests/ModelServiceTests.swift
+++ b/OrchardTests/ModelServiceTests.swift
@@ -26,7 +26,7 @@ private func makeNetwork(id: String = "default", gateway: String? = "192.168.66.
 
 @MainActor
 private func makeModelService(backend: ModelBackend) -> ModelService {
-    ModelService(backend: backend, settings: SettingsStore(alertCenter: AlertCenter(), defaults: ephemeralDefaults()))
+    ModelService(backend: backend, settings: SettingsStore(alertCenter: AlertCenter(), defaults: ephemeralDefaults(), secrets: InMemorySecretsStore()))
 }
 
 // MARK: - load

--- a/OrchardTests/SettingsStoreTests.swift
+++ b/OrchardTests/SettingsStoreTests.swift
@@ -17,7 +17,7 @@ private func withSettingsStore(_ body: (SettingsStore, UserDefaults) -> Void) {
     let name = "OrchardTests-\(UUID().uuidString)"
     let defaults = UserDefaults(suiteName: name)!
     defer { defaults.removePersistentDomain(forName: name) }
-    body(SettingsStore(alertCenter: AlertCenter(), defaults: defaults), defaults)
+    body(SettingsStore(alertCenter: AlertCenter(), defaults: defaults, secrets: InMemorySecretsStore()), defaults)
 }
 
 // MARK: - validateAndSetCustomBinaryPath
@@ -118,5 +118,25 @@ func preferredTerminalPersists() {
         // No fresh-store round-trip assertion: `.terminal` is the default AND the
         // always-installed first fallback, so a reloaded store returns it whether or not
         // the persisted value is read — the read path can't be falsifiably round-tripped.
+    }
+}
+
+// MARK: - Model API keys
+
+@MainActor
+@Test("Model API keys: set, read back, clear, and enumerate per port")
+func modelAPIKeyRoundTrip() {
+    withSettingsStore { store, _ in
+        #expect(store.modelAPIKey(port: 8000) == nil)
+
+        store.setModelAPIKey("sk-test", port: 8000)
+        store.setModelAPIKey("sk-other", port: 1234)
+        #expect(store.modelAPIKey(port: 8000) == "sk-test")
+        #expect(store.allModelAPIKeys() == [8000: "sk-test", 1234: "sk-other"])
+
+        store.setModelAPIKey("", port: 8000)    // empty clears
+        #expect(store.modelAPIKey(port: 8000) == nil)
+        store.setModelAPIKey(nil, port: 1234)   // nil clears
+        #expect(store.allModelAPIKeys().isEmpty)
     }
 }


### PR DESCRIPTION
## What does this PR do?

Makes the AI Models section recognise [oMLX](https://github.com/jundot/omlx) servers by name.

oMLX defaults to `http://localhost:8000/v1` and exposes `GET /v1/models`, which is the same conventional port and path the existing probe already checks, so an oMLX server was in fact detected, but displayed as a generic "MLX Server". Its models listing stamps `"owned_by": "omlx"` on every model (see `omlx/api/openai_models.py` in the oMLX repo), which gives a reliable fingerprint.

Changes:

- **`ModelProvider.Kind`**: new `omlx` case, displayed as "oMLX"
- **`LiveModelBackend`**: a pure `refineKind` step in the probe reclassifies an OpenAI-style hit as oMLX when any listed model carries `owned_by == "omlx"`. Any other value (`mlx`, missing, garbage JSON) or a non-OpenAI API keeps the candidate's kind
- **`ModelBridgeTests`**: 2 new tests (5 scenarios) covering reclassification and every passthrough branch

Since `refineKind` runs on all OpenAI-style candidates, an oMLX server on the LM Studio port (1234) or the 8080 fallback is also identified correctly.

### API-keyed servers (added after live testing)

Real-world testing against an actual oMLX install surfaced a gap: the menu-bar app generates an API key at setup and answers unauthenticated requests with 401, so the detection above never saw it. This PR now also:

- surfaces a 401/403 on a conventional port as a **locked provider** ("API key required") instead of hiding the server
- adds a key field to the provider detail; the key is stored per port and used by the detection probe, model listing, the chat tester, and the container bridge (`OPENAI_API_KEY` gets the real key instead of the placeholder)
- extracts probe classification into a pure, tested function (200 / 401 / other)

Keys are stored in UserDefaults rather than the keychain: they guard loopback-only servers, and the provider identity is the port, matching how the rest of settings persistence works.

Also addressed the review comment: `ModelProvider.id` is now `api:port` (both from the static probe candidate), so kind refinement can't flap identity-based UI state.

## Related issues

Closes #72

## Screenshots / recording

No layout change: the provider card in AI Models reads "oMLX" instead of "MLX Server" when an oMLX server is detected.

## Checklist

- [x] The project builds and runs (`Orchard` scheme)
- [x] Tests pass (`⌘U` / `xcodebuild test`) - 212/212
- [x] I've added an entry to `CHANGELOG.md` (Added / Changed / Fixed)
- [x] The change is focused on a single logical concern

