### PR TITLE
Keep the Run Container sheet open when the run fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Multi-selection across containers, images, mounts, DNS domains, and networks: shift-click range selection, Command+A select-all, batch deletion, and a summary detail view for the selection ([#53](https://github.com/andrew-waters/orchard/pull/53)).
 
 ### Fixed
+- The Run Container sheet now stays open when the run fails, so the configuration can be adjusted and retried; previously it dismissed regardless, leaving only the error alert.
 - When the container system is stopped or XPC is unreachable, Orchard no longer storms error dialogs from background refresh. Failed XPC connections surface as a clear "container service is unavailable" message, and after starting the system Orchard waits until the service is actually reachable before loading data.
 - Running containers' stop buttons in the menu-bar panel now respond on first click.
 

--- a/Orchard/Views/Features/Containers/RunContainer.swift
+++ b/Orchard/Views/Features/Containers/RunContainer.swift
@@ -230,12 +230,15 @@ struct RunContainerView: View {
             let started = await containerListService.runContainer(config: runConfig)
             await MainActor.run {
                 isRunning = false
+                // runContainer surfaces its own error; keep the sheet open on failure so
+                // the user can adjust the form and retry (matches RunModelContainer).
+                guard started else { return }
                 dismiss()
                 // Non-detached run: open the user's preferred terminal attached to the
                 // container. The service uses config.name as the container id (the Run
                 // button is disabled while the name is empty), and the container is
                 // already started by the time runContainer returns (#43).
-                if started && !config.detached {
+                if !config.detached {
                     terminalLauncher.openTerminal(for: config.name)
                 }
             }


### PR DESCRIPTION
## What does this PR do?

Keeps the Run Container sheet open when the run fails, so the configuration can be adjusted and retried. Previously the sheet dismissed regardless of outcome, leaving only the error alert; the non-detached terminal attach was already gated on success, but the dismiss wasn't. RunModelContainer already handles this correctly - this brings RunContainerView in line with it.

Surfaced by review feedback on #49 (the finding was against code introduced by #43, so it's fixed here on main rather than in that PR).

## Related issues

Follow-up to #43; addresses a review finding raised on #49.

## Screenshots / recording

Behavioural change only: on a failed run the sheet now stays open with the error alert.

## Checklist

- [x] The project builds and runs (`Orchard` scheme)
- [x] Tests pass (`⌘U` / `xcodebuild test`) - 219/219
- [x] I've added an entry to `CHANGELOG.md` (Added / Changed / Fixed)
- [x] The change is focused on a single logical concern
