### PR TITLE
Support Apple container 1.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- Orchard now links the Apple container 1.2.2 client libraries (previously 1.1.0), restoring compatibility with current container installs ([#54](https://github.com/andrew-waters/orchard/issues/54)).
+- When the installed container release doesn't match the client Orchard links, the app now shows the version-incompatibility screen with upgrade guidance instead of reporting the system as stopped with a raw health-check decode error ([#37](https://github.com/andrew-waters/orchard/issues/37), [#39](https://github.com/andrew-waters/orchard/issues/39)).
+
 ## [2.1.6] - 2026-08-20
 
 ### Added

--- a/Orchard.xcodeproj/project.pbxproj
+++ b/Orchard.xcodeproj/project.pbxproj
@@ -622,7 +622,7 @@
 			repositoryURL = "https://github.com/apple/container.git";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 1.1.0;
+				minimumVersion = 1.2.2;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/Orchard.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Orchard.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,0 +1,321 @@
+{
+  "originHash" : "1662382dd50b8bdfef945b0c1bb75758bc375f5c7da786e2872a042d835e5992",
+  "pins" : [
+    {
+      "identity" : "async-http-client",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swift-server/async-http-client.git",
+      "state" : {
+        "revision" : "3a5b74a58782c3b4c1f0bc75e9b67b10c2494e8f",
+        "version" : "1.33.1"
+      }
+    },
+    {
+      "identity" : "container",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/container.git",
+      "state" : {
+        "revision" : "0190097d06df0b9065f4c2d2c7873c649d81d493",
+        "version" : "1.2.2"
+      }
+    },
+    {
+      "identity" : "containerization",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/containerization.git",
+      "state" : {
+        "revision" : "7800b4642171561c95b5f55500b19e5dce5acd45",
+        "version" : "0.40.1"
+      }
+    },
+    {
+      "identity" : "grpc-swift-2",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/grpc/grpc-swift-2.git",
+      "state" : {
+        "revision" : "d19a94824cc6fa182211e8197ce391ff712b69f1",
+        "version" : "2.4.0"
+      }
+    },
+    {
+      "identity" : "grpc-swift-nio-transport",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/grpc/grpc-swift-nio-transport.git",
+      "state" : {
+        "revision" : "eaad084d6c26ff1f2e96f9c2ab76ef84d7165ab6",
+        "version" : "2.9.2"
+      }
+    },
+    {
+      "identity" : "grpc-swift-protobuf",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/grpc/grpc-swift-protobuf.git",
+      "state" : {
+        "revision" : "8723cf856dc23d9c2fad4d874e7b9ed3254acf03",
+        "version" : "2.3.0"
+      }
+    },
+    {
+      "identity" : "sparkle",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/sparkle-project/Sparkle",
+      "state" : {
+        "revision" : "b6496a74a087257ef5e6da1c5b29a447a60f5bd7",
+        "version" : "2.9.4"
+      }
+    },
+    {
+      "identity" : "swift-algorithms",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-algorithms.git",
+      "state" : {
+        "revision" : "87e50f483c54e6efd60e885f7f5aa946cee68023",
+        "version" : "1.2.1"
+      }
+    },
+    {
+      "identity" : "swift-argument-parser",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-argument-parser.git",
+      "state" : {
+        "revision" : "626b5b7b2f45e1b0b1c6f4a309296d1d21d7311b",
+        "version" : "1.7.1"
+      }
+    },
+    {
+      "identity" : "swift-asn1",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-asn1.git",
+      "state" : {
+        "revision" : "9f542610331815e29cc3821d3b6f488db8715517",
+        "version" : "1.6.0"
+      }
+    },
+    {
+      "identity" : "swift-async-algorithms",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-async-algorithms.git",
+      "state" : {
+        "revision" : "9d349bcc328ac3c31ce40e746b5882742a0d1272",
+        "version" : "1.1.3"
+      }
+    },
+    {
+      "identity" : "swift-atomics",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-atomics.git",
+      "state" : {
+        "revision" : "b601256eab081c0f92f059e12818ac1d4f178ff7",
+        "version" : "1.3.0"
+      }
+    },
+    {
+      "identity" : "swift-certificates",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-certificates.git",
+      "state" : {
+        "revision" : "24ccdeeeed4dfaae7955fcac9dbf5489ed4f1a25",
+        "version" : "1.18.0"
+      }
+    },
+    {
+      "identity" : "swift-collections",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-collections.git",
+      "state" : {
+        "revision" : "6675bc0ff86e61436e615df6fc5174e043e57924",
+        "version" : "1.4.1"
+      }
+    },
+    {
+      "identity" : "swift-configuration",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-configuration.git",
+      "state" : {
+        "revision" : "be76c4ad929eb6c4bcaf3351799f2adf9e6848a9",
+        "version" : "1.2.0"
+      }
+    },
+    {
+      "identity" : "swift-configuration-toml",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/mattt/swift-configuration-toml",
+      "state" : {
+        "revision" : "4ea16b4dfa4b023cecae5ae0368402c4d846d613",
+        "version" : "2.0.0"
+      }
+    },
+    {
+      "identity" : "swift-crypto",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-crypto.git",
+      "state" : {
+        "revision" : "95ba0316a9b733e92bb6b071255ff46263bbe7dc",
+        "version" : "3.15.1"
+      }
+    },
+    {
+      "identity" : "swift-distributed-tracing",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-distributed-tracing.git",
+      "state" : {
+        "revision" : "dc4030184203ffafbb2ec614352487235d747fe0",
+        "version" : "1.4.1"
+      }
+    },
+    {
+      "identity" : "swift-http-structured-headers",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-http-structured-headers.git",
+      "state" : {
+        "revision" : "76d7627bd88b47bf5a0f8497dd244885960dde0b",
+        "version" : "1.6.0"
+      }
+    },
+    {
+      "identity" : "swift-http-types",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-http-types.git",
+      "state" : {
+        "revision" : "45eb0224913ea070ec4fba17291b9e7ecf4749ca",
+        "version" : "1.5.1"
+      }
+    },
+    {
+      "identity" : "swift-log",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-log.git",
+      "state" : {
+        "revision" : "8c0f217f01000dd30f60d6e536569ad4e74291f9",
+        "version" : "1.11.0"
+      }
+    },
+    {
+      "identity" : "swift-metrics",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-metrics",
+      "state" : {
+        "revision" : "087e8074afa97040c3b870c8664fe5482fb87cc4",
+        "version" : "2.11.0"
+      }
+    },
+    {
+      "identity" : "swift-nio",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio.git",
+      "state" : {
+        "revision" : "558f24a4647193b5a0e2104031b71c55d31ff83a",
+        "version" : "2.97.1"
+      }
+    },
+    {
+      "identity" : "swift-nio-extras",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio-extras.git",
+      "state" : {
+        "revision" : "abcf5312eb8ed2fb11916078aef7c46b06f20813",
+        "version" : "1.33.0"
+      }
+    },
+    {
+      "identity" : "swift-nio-http2",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio-http2.git",
+      "state" : {
+        "revision" : "6d8d596f0a9bfebb925733003731fe2d749b7e02",
+        "version" : "1.42.0"
+      }
+    },
+    {
+      "identity" : "swift-nio-ssl",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio-ssl.git",
+      "state" : {
+        "revision" : "df9c3406028e3297246e6e7081977a167318b692",
+        "version" : "2.36.1"
+      }
+    },
+    {
+      "identity" : "swift-nio-transport-services",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio-transport-services.git",
+      "state" : {
+        "revision" : "60c3e187154421171721c1a38e800b390680fb5d",
+        "version" : "1.26.0"
+      }
+    },
+    {
+      "identity" : "swift-numerics",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-numerics.git",
+      "state" : {
+        "revision" : "0c0290ff6b24942dadb83a929ffaaa1481df04a2",
+        "version" : "1.1.1"
+      }
+    },
+    {
+      "identity" : "swift-protobuf",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-protobuf.git",
+      "state" : {
+        "revision" : "a008af1a102ff3dd6cc3764bb69bf63226d0f5f6",
+        "version" : "1.36.1"
+      }
+    },
+    {
+      "identity" : "swift-service-context",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-service-context.git",
+      "state" : {
+        "revision" : "d0997351b0c7779017f88e7a93bc30a1878d7f29",
+        "version" : "1.3.0"
+      }
+    },
+    {
+      "identity" : "swift-service-lifecycle",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swift-server/swift-service-lifecycle.git",
+      "state" : {
+        "revision" : "9829955b385e5bb88128b73f1b8389e9b9c3191a",
+        "version" : "2.11.0"
+      }
+    },
+    {
+      "identity" : "swift-system",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-system.git",
+      "state" : {
+        "revision" : "7c6ad0fc39d0763e0b699210e4124afd5041c5df",
+        "version" : "1.6.4"
+      }
+    },
+    {
+      "identity" : "swift-toml",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/mattt/swift-toml.git",
+      "state" : {
+        "revision" : "827506c90475e82d5a7f191f950fb3025cbdc0d6",
+        "version" : "2.0.0"
+      }
+    },
+    {
+      "identity" : "yams",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/jpsim/Yams.git",
+      "state" : {
+        "revision" : "deaf82e867fa2cbd3cd865978b079bfcf384ac28",
+        "version" : "6.2.1"
+      }
+    },
+    {
+      "identity" : "zstd",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/facebook/zstd.git",
+      "state" : {
+        "revision" : "f8745da6ff1ad1e7bab384bd1f9d742439278e99",
+        "version" : "1.5.7"
+      }
+    }
+  ],
+  "version" : 3
+}

--- a/Orchard/Services/ContainerBackend.swift
+++ b/Orchard/Services/ContainerBackend.swift
@@ -112,6 +112,17 @@ func mapContainerError(_ error: Error) -> Error {
     isContainerServiceUnavailable(error) ? OrchardError.xpcUnavailable : error
 }
 
+/// The apple/container release Orchard's client libraries are built against. Keep in
+/// sync with the container package pin in project.pbxproj when bumping.
+let supportedContainerVersion = "1.2.2"
+
+/// A ping reply the linked client cannot decode means the installed daemon speaks a
+/// different protocol revision than the client libraries Orchard links.
+func isContainerVersionMismatch(_ error: Error) -> Bool {
+    let message = error.localizedDescription.lowercased()
+    return message.contains("failed to decode") && message.contains("health check")
+}
+
 func isContainerServiceUnavailable(_ error: Error) -> Bool {
     let message = error.localizedDescription.lowercased()
     return message.contains("connection invalid")

--- a/Orchard/Services/SystemService.swift
+++ b/Orchard/Services/SystemService.swift
@@ -111,16 +111,21 @@ final class SystemService: ObservableObject {
             
             // The CLI command returned, but the XPC daemon might need a moment to bind.
             // Poll until ping succeeds so we don't transition the UI while XPC is unreachable.
+            // A version mismatch is terminal, not transient: stop polling and let the
+            // version-incompatibility screen take over instead of alerting an outage.
             var attempts = 0
             while attempts < 10 {
                 await checkSystemStatus()
-                if systemStatus == .running { break }
+                if systemStatus == .running || systemStatus == .unsupportedVersion { break }
                 try? await Task.sleep(nanoseconds: 500_000_000) // 0.5s
                 attempts += 1
             }
             
             isSystemLoading = false
             
+            if systemStatus == .unsupportedVersion {
+                return
+            }
             if systemStatus != .running {
                 alertCenter.error("System started but container service is unreachable.")
                 return

--- a/Orchard/Services/SystemService.swift
+++ b/Orchard/Services/SystemService.swift
@@ -76,7 +76,10 @@ final class SystemService: ObservableObject {
         } catch {
             self.containerVersion = nil
             self.parsedContainerVersion = nil
-            self.systemStatus = .stopped
+            // A health check the linked client can't decode isn't an outage: the daemon
+            // is up but speaking a different container release. Gate on version instead
+            // of reporting "stopped" with a cryptic decode error (#37, #39, #54).
+            self.systemStatus = isContainerVersionMismatch(error) ? .unsupportedVersion : .stopped
             self.systemStatusError = "\(type(of: error)): \(String(describing: error))"
         }
     }

--- a/Orchard/Views/States/VersionIncompatibility.swift
+++ b/Orchard/Views/States/VersionIncompatibility.swift
@@ -13,27 +13,19 @@ struct VersionIncompatibilityView: View {
                     .font(.title)
                     .fontWeight(.semibold)
 
-                if let installedVersion = systemService.parsedContainerVersion {
-                    Text("We require Apple Container version \(systemService.parsedContainerVersion ?? "unknown"), but you are running version \(installedVersion)")
-                        .padding(.horizontal)
-                        .multilineTextAlignment(.center)
-                } else if let rawVersion = systemService.containerVersion {
-                    Text("Detected version: \(rawVersion)")
-                        .font(.subheadline)
-                        .foregroundColor(.secondary)
-                        .padding(.horizontal)
-                        .multilineTextAlignment(.center)
+                Text("This build of Orchard talks to Apple container \(supportedContainerVersion), but the installed container service is a different release the app can't communicate with.")
+                    .padding(.horizontal)
+                    .multilineTextAlignment(.center)
 
-                    Text("We require Apple Container version \(systemService.parsedContainerVersion ?? "unknown")")
-                        .font(.subheadline)
+                if let detail = systemService.systemStatusError {
+                    Text(detail)
+                        .font(.caption)
                         .foregroundColor(.secondary)
-                } else {
-                    Text("We require Apple Container version \(systemService.parsedContainerVersion ?? "unknown")")
-                        .font(.subheadline)
-                        .foregroundColor(.secondary)
+                        .multilineTextAlignment(.center)
+                        .padding(.horizontal)
                 }
 
-                Text("Please update your Container installation to continue using this application.")
+                Text("Update your container installation (or Orchard) so the versions match, then check again.")
                     .font(.body)
                     .foregroundColor(.primary)
                     .multilineTextAlignment(.center)

--- a/OrchardTests/Mocks.swift
+++ b/OrchardTests/Mocks.swift
@@ -64,6 +64,7 @@ final class MockContainerBackend: ContainerBackend, @unchecked Sendable {
     private var _killContainerError: Error?
     private var _deleteContainerError: Error?
     private var _pingError: Error?
+    private var _pingCount = 0
     private var _bootstrapAndStartHandler: (@Sendable (Int) throws -> Void)?
     private var _statsHandler: (@Sendable (String) throws -> Orchard.ContainerStats)?
 
@@ -137,6 +138,8 @@ final class MockContainerBackend: ContainerBackend, @unchecked Sendable {
         get { lock.withLock { _pingError } }
         set { lock.withLock { _pingError = newValue } }
     }
+    /// Number of `ping()` calls, for asserting how often a poll retried.
+    var pingCount: Int { lock.withLock { _pingCount } }
     /// Called with the 1-based attempt count; throw to simulate a failed start.
     var bootstrapAndStartHandler: (@Sendable (Int) throws -> Void)? {
         get { lock.withLock { _bootstrapAndStartHandler } }
@@ -213,6 +216,7 @@ final class MockContainerBackend: ContainerBackend, @unchecked Sendable {
         lock.withLock { _deletedNetworkIds.append(id) }
     }
     func ping() async throws -> SystemHealthInfo {
+        lock.withLock { _pingCount += 1 }
         if let pingError { throw pingError }
         return SystemHealthInfo(apiServerVersion: "test")
     }

--- a/OrchardTests/OrchardErrorTests.swift
+++ b/OrchardTests/OrchardErrorTests.swift
@@ -71,3 +71,17 @@ func mapContainerErrorRewritesXPC() {
     let other = mapContainerError(error("disk full"))
     #expect(other.localizedDescription == "disk full")
 }
+
+@Test("isContainerVersionMismatch: matches undecodable health-check replies, not outages")
+func containerVersionMismatchClassifier() {
+    for message in [
+        "internalError: \"failed to decode apiServerBuild in health check\"",
+        "failed to decode apiServerAppName in health check",
+        "Failed to decode appRoot in health check",
+    ] {
+        #expect(isContainerVersionMismatch(error(message)) == true, "expected match for: \(message)")
+    }
+    #expect(isContainerVersionMismatch(error("The connection was invalidated.")) == false)
+    #expect(isContainerVersionMismatch(error("failed to decode container list")) == false)
+    #expect(isContainerVersionMismatch(error("disk full")) == false)
+}

--- a/OrchardTests/SystemServiceTests.swift
+++ b/OrchardTests/SystemServiceTests.swift
@@ -73,4 +73,5 @@ func startSystemVersionMismatchGates() async {
     #expect(service.systemService.systemStatus == .unsupportedVersion)
     #expect(service.alertCenter.current == nil)   // gated by the version screen, not an alert
     #expect(service.systemService.isSystemLoading == false)
+    #expect(backend.pingCount == 1)   // mismatch is terminal: no retry sleeps
 }

--- a/OrchardTests/SystemServiceTests.swift
+++ b/OrchardTests/SystemServiceTests.swift
@@ -1,4 +1,5 @@
 import Testing
+import Foundation
 @testable import Orchard
 
 @MainActor
@@ -40,4 +41,19 @@ func stopSystemFailureReDerives() async {
 
     #expect(service.systemService.systemStatus == .running)   // re-derived, not forced .stopped
     #expect(service.alertCenter.current != nil)
+}
+
+@MainActor
+@Test("checkSystemStatus: undecodable health check gates on version, not .stopped")
+func checkSystemStatusVersionMismatch() async {
+    let backend = MockContainerBackend()
+    backend.pingError = NSError(
+        domain: "test", code: 1,
+        userInfo: [NSLocalizedDescriptionKey: "internalError: \"failed to decode apiServerBuild in health check\""])
+    let service = makeService(backend: backend)
+
+    await service.systemService.checkSystemStatus()
+
+    #expect(service.systemService.systemStatus == .unsupportedVersion)
+    #expect(service.systemService.systemStatusError?.isEmpty == false)
 }

--- a/OrchardTests/SystemServiceTests.swift
+++ b/OrchardTests/SystemServiceTests.swift
@@ -57,3 +57,20 @@ func checkSystemStatusVersionMismatch() async {
     #expect(service.systemService.systemStatus == .unsupportedVersion)
     #expect(service.systemService.systemStatusError?.isEmpty == false)
 }
+
+@MainActor
+@Test("startSystem: a version mismatch stops the readiness poll without an outage alert")
+func startSystemVersionMismatchGates() async {
+    let runner = MockCommandRunner()   // `system start` exits 0
+    let backend = MockContainerBackend()
+    backend.pingError = NSError(
+        domain: "test", code: 1,
+        userInfo: [NSLocalizedDescriptionKey: "failed to decode apiServerBuild in health check"])
+    let service = makeService(backend: backend, runner: runner)
+
+    await service.systemService.startSystem()
+
+    #expect(service.systemService.systemStatus == .unsupportedVersion)
+    #expect(service.alertCenter.current == nil)   // gated by the version screen, not an alert
+    #expect(service.systemService.isSystemLoading == false)
+}


### PR DESCRIPTION
## What does this PR do?

Bumps the apple/container package pin from 1.1.0 to 1.2.2 (pulling containerization 0.40.1). The client API surface Orchard uses is source compatible, so no backend changes were required; the point of the bump is the XPC protocol. Orchard 2.1.x links the 1.1.0 client against what is now a 1.2.x daemon for anyone tracking brew, which reproduces the classic mismatch failure mode: health checks fail with `failed to decode apiServerBuild in health check` and container actions silently no-op.

While here, the mismatch is made legible instead of mysterious:

- A ping reply the linked client cannot decode is now classified as a version mismatch (`isContainerVersionMismatch`) rather than an outage, and gates on the version-incompatibility screen instead of showing "not running" with a raw decode error.
- The incompatibility screen states the supported container release (via a `supportedContainerVersion` constant kept in sync with the package pin), shows the underlying diagnostic, and keeps the upgrade-instructions and re-check buttons. Its previous copy interpolated the *detected* version as the *required* version, which read as nonsense.
- `Package.resolved` is restored to version control; it was inadvertently deleted in #68, leaving CI and release builds to float on dependency resolution.

## Related issues

Closes #54. Same failure mode as #37 / #39.

## Screenshots / recording

The only UI change is copy on `VersionIncompatibilityView` (reachable only with a mismatched daemon). New copy:

> **Unsupported Container Version**
> This build of Orchard talks to Apple container 1.2.2, but the installed container service is a different release the app can't communicate with.
> *(diagnostic detail)*
> Update your container installation (or Orchard) so the versions match, then check again.

## Checklist

- [x] The project builds and runs (`Orchard` scheme)
- [x] Tests pass (`⌘U` / `xcodebuild test`) — 225 tests
- [x] I've added an entry to `CHANGELOG.md` (Added / Changed / Fixed)
- [x] The change is focused on a single logical concern