### PR TITLE
Badge plugin-owned containers with their plugin and role

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Containers owned by a container plugin (such as k8s cluster nodes) are badged in the containers list and detail header with the owning plugin and their role, e.g. "k8s · control-plane", so kindest/node containers aren't mystery rows.
+
 ## [2.1.7] - 2026-08-20
 
 ### Changed

--- a/Orchard/Services/PluginResource.swift
+++ b/Orchard/Services/PluginResource.swift
@@ -1,0 +1,30 @@
+import Foundation
+
+/// System-defined label keys for resources owned by container plugins, mirroring
+/// ResourceLabelKeys in apple/container. The k8s plugin, for example, stamps its node
+/// containers with plugin "k8s" and roles "control-plane"/"worker".
+enum PluginResourceMarker {
+    static let pluginLabel = "com.apple.container.plugin"
+    static let roleLabel = "com.apple.container.resource.role"
+}
+
+extension Container {
+    /// The container plugin that owns this container (e.g. "k8s"), if any.
+    var owningPlugin: String? {
+        configuration.labels[PluginResourceMarker.pluginLabel]
+    }
+
+    /// The dedicated role the owning plugin assigned ("control-plane", "worker",
+    /// "builder"), if any.
+    var pluginRole: String? {
+        configuration.labels[PluginResourceMarker.roleLabel]
+    }
+
+    /// Badge text for a plugin-owned container: the plugin plus its role, so a
+    /// kindest/node container reads as "k8s · control-plane" rather than a mystery row.
+    var pluginBadgeText: String? {
+        guard let plugin = owningPlugin else { return nil }
+        guard let role = pluginRole else { return plugin }
+        return "\(plugin) · \(role)"
+    }
+}

--- a/Orchard/Views/Components/ListItemRow.swift
+++ b/Orchard/Views/Components/ListItemRow.swift
@@ -9,6 +9,8 @@ struct ListItemRow: View {
     let isSelected: Bool
     /// When true, a small shield marks the row as a sandbox (wired to a local model).
     let showSandboxBadge: Bool
+    /// Plugin + role capsule for plugin-owned containers (e.g. "k8s · control-plane").
+    let pluginBadge: String?
 
     init(
         icon: String,
@@ -17,7 +19,8 @@ struct ListItemRow: View {
         secondaryLeftText: String? = nil,
         secondaryRightText: String? = nil,
         isSelected: Bool = false,
-        showSandboxBadge: Bool = false
+        showSandboxBadge: Bool = false,
+        pluginBadge: String? = nil
     ) {
         self.icon = icon
         self.iconColor = iconColor
@@ -26,6 +29,7 @@ struct ListItemRow: View {
         self.secondaryRightText = secondaryRightText
         self.isSelected = isSelected
         self.showSandboxBadge = showSandboxBadge
+        self.pluginBadge = pluginBadge
     }
 
     var body: some View {
@@ -50,6 +54,16 @@ struct ListItemRow: View {
                             .font(.system(size: 11))
                             .foregroundColor(.accentColor)
                             .help("Sandbox - wired to a local model")
+                    }
+                    if let pluginBadge {
+                        Text(pluginBadge)
+                            .font(.system(size: 9, weight: .medium))
+                            .foregroundColor(.accentColor)
+                            .padding(.horizontal, 5)
+                            .padding(.vertical, 1.5)
+                            .background(Capsule().fill(Color.accentColor.opacity(0.14)))
+                            .lineLimit(1)
+                            .help("Managed by a container plugin")
                     }
                 }
 

--- a/Orchard/Views/Features/Containers/ContainerDetailHeader.swift
+++ b/Orchard/Views/Features/Containers/ContainerDetailHeader.swift
@@ -13,6 +13,7 @@ struct ContainerDetailHeader: View {
     @State private var isStopping = false
     @State private var wasRunningBeforeStop = false
     @State private var showSandboxInfo = false
+    @State private var showPluginInfo = false
 
     /// Shield badge shown when the container is a sandbox (wired to a local model). Tapping
     /// it explains what that means and shows the endpoint - since a sandbox appears in both
@@ -41,6 +42,45 @@ struct ContainerDetailHeader: View {
                         .font(.caption)
                         .foregroundColor(.secondary)
                     Text(endpoint)
+                        .font(.system(.caption, design: .monospaced))
+                        .textSelection(.enabled)
+                }
+            }
+            .padding(14)
+            .frame(width: 300)
+        }
+    }
+
+    /// Capsule badge shown when a plugin owns the container (e.g. a k8s cluster node).
+    /// Tapping it explains which plugin manages it and what role the container plays.
+    private var pluginBadge: some View {
+        Button(action: { showPluginInfo.toggle() }) {
+            Text(container.pluginBadgeText ?? "")
+                .font(.system(size: 11, weight: .medium))
+                .foregroundColor(.accentColor)
+                .padding(.horizontal, 7)
+                .padding(.vertical, 2)
+                .background(Capsule().fill(Color.accentColor.opacity(0.14)))
+        }
+        .buttonStyle(.plain)
+        .help("Managed by the \(container.owningPlugin ?? "container") plugin")
+        .popover(isPresented: $showPluginInfo) {
+            VStack(alignment: .leading, spacing: 8) {
+                HStack(spacing: 6) {
+                    SwiftUI.Image(systemName: "puzzlepiece.extension")
+                        .foregroundColor(.accentColor)
+                    Text("Plugin-managed container")
+                        .font(.headline)
+                }
+                Text("This container is created and managed by the '\(container.owningPlugin ?? "")' container plugin. Its lifecycle is tied to the plugin's resources, so prefer the plugin's commands over acting on it directly.")
+                    .font(.callout)
+                    .foregroundColor(.secondary)
+                if let role = container.pluginRole {
+                    Divider()
+                    Text("Role")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                    Text(role)
                         .font(.system(.caption, design: .monospaced))
                         .textSelection(.enabled)
                 }
@@ -120,6 +160,9 @@ struct ContainerDetailHeader: View {
                         .fontWeight(.semibold)
                     if container.isSandbox {
                         sandboxBadge
+                    }
+                    if container.pluginBadgeText != nil {
+                        pluginBadge
                     }
                 }
                 Text(imageReference)

--- a/Orchard/Views/Features/Containers/ListContainers.swift
+++ b/Orchard/Views/Features/Containers/ListContainers.swift
@@ -25,7 +25,8 @@ struct ContainersListView: View {
                         secondaryLeftText: networkAddress(for: container) ?? "-",
                         secondaryRightText: hostname(for: container),
                         isSelected: selectedContainers.contains(container.configuration.id),
-                        showSandboxBadge: container.isSandbox
+                        showSandboxBadge: container.isSandbox,
+                        pluginBadge: container.pluginBadgeText
                     )
                     .contextMenu {
                         contextMenu(for: container)

--- a/OrchardTests/Mocks.swift
+++ b/OrchardTests/Mocks.swift
@@ -236,7 +236,10 @@ private func fixtureImageJSON(_ reference: String) -> String {
     #"{ "reference": "\#(reference)", "descriptor": { "mediaType": "application/vnd.oci.image.index.v1+json", "digest": "sha256:abc", "size": 0 } }"#
 }
 
-func makeContainer(id: String, status: String) throws -> Container {
+func makeContainer(id: String, status: String, labels: [String: String] = [:]) throws -> Container {
+    let labelsJSON = labels.isEmpty
+        ? "{}"
+        : String(data: try JSONEncoder().encode(labels), encoding: .utf8)!
     let json = """
     {
       "status": "\(status)",
@@ -245,7 +248,7 @@ func makeContainer(id: String, status: String) throws -> Container {
         "id": "\(id)",
         "runtimeHandler": "vz",
         "rosetta": false,
-        "labels": {},
+        "labels": \(labelsJSON),
         "sysctls": {},
         "publishedPorts": [],
         "mounts": [],

--- a/OrchardTests/PluginResourceTests.swift
+++ b/OrchardTests/PluginResourceTests.swift
@@ -1,0 +1,40 @@
+import Testing
+@testable import Orchard
+
+@Test("Plugin marker: k8s node labels resolve plugin, role, and badge text")
+func pluginLabelsResolve() throws {
+    let node = try makeContainer(
+        id: "k8s-dev", status: "running",
+        labels: [
+            "com.apple.container.plugin": "k8s",
+            "com.apple.container.resource.role": "control-plane",
+        ])
+    #expect(node.owningPlugin == "k8s")
+    #expect(node.pluginRole == "control-plane")
+    #expect(node.pluginBadgeText == "k8s · control-plane")
+}
+
+@Test("Plugin marker: a plugin label without a role badges as the plugin alone")
+func pluginWithoutRole() throws {
+    let container = try makeContainer(
+        id: "helper", status: "running",
+        labels: ["com.apple.container.plugin": "k8s"])
+    #expect(container.pluginBadgeText == "k8s")
+    #expect(container.pluginRole == nil)
+}
+
+@Test("Plugin marker: unlabeled containers get no badge")
+func unlabeledContainer() throws {
+    let container = try makeContainer(id: "web", status: "running")
+    #expect(container.owningPlugin == nil)
+    #expect(container.pluginBadgeText == nil)
+}
+
+@Test("Plugin marker: a bare role label (e.g. builder) does not badge without an owner")
+func roleWithoutPlugin() throws {
+    let container = try makeContainer(
+        id: "buildkit", status: "running",
+        labels: ["com.apple.container.resource.role": "builder"])
+    #expect(container.pluginBadgeText == nil)
+    #expect(container.pluginRole == "builder")
+}


### PR DESCRIPTION
## What does this PR do?

Containers created by a container plugin (the k8s plugin's cluster nodes, for instance) carry the `com.apple.container.plugin` and `com.apple.container.resource.role` labels. This surfaces them in the UI the same way sandbox containers get their shield badge:

- The containers list row shows a small capsule badge with the owning plugin and role, e.g. `k8s · control-plane`, so a `kindest/node` container isn't a mystery row.
- The container detail header shows the same capsule; clicking it opens a popover explaining that the plugin manages the container's lifecycle (and that acting on it directly is usually the wrong tool), plus the role.

The label keys mirror upstream `ResourceLabelKeys` in apple/container (`Sources/ContainerResource/Common/ResourceLabels.swift`). A container with a bare role label but no owning plugin (like the builtin builder) does not badge.

Note: this branch also restores `Package.resolved` with content identical to #83 (it was untracked on main after #68). Whichever PR merges first, the other's copy is a no-op.

## Related issues

Groundwork for the upcoming k8s clusters view; pairs with #83.

## Screenshots / recording

The badge is only visible with plugin-owned containers (a `container k8s create` cluster node). Rendered form: an accent-tinted capsule reading `k8s · control-plane` beside the container name, in both the list row (9pt) and the detail header (11pt, clickable popover).

## Checklist

- [x] The project builds and runs (`Orchard` scheme)
- [x] Tests pass (`⌘U` / `xcodebuild test`) — 227 tests
- [x] I've added an entry to `CHANGELOG.md` (Added / Changed / Fixed)
- [x] The change is focused on a single logical concern