### PR TITLE
Inset the detail column below the window controls when the sidebar hides

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Containers owned by a container plugin (such as k8s cluster nodes) are badged in the containers list and detail header with the owning plugin and their role, e.g. "k8s · control-plane", so kindest/node containers aren't mystery rows.
 - Clusters: a new sidebar section for local Kubernetes clusters created with the `container k8s` plugin (container 1.2.2+). Node containers are grouped into clusters with per-node role, status, IP, CPUs, memory, and published ports; clusters can be created, started, and deleted from the UI, local images can be loaded into a cluster's containerd, and the kubeconfig can be written or its path copied, with a one-click terminal preconfigured for kubectl. Installs without the plugin get an explanatory state with upgrade guidance.
 
+### Fixed
+- With the sidebar hidden, the Dashboard (and other full-width pages) no longer render underneath the macOS window controls ([#88](https://github.com/andrew-waters/orchard/issues/88)).
+
 ## [2.1.7] - 2026-08-20
 
 ### Changed

--- a/Orchard/Views/Layout/ThreeColumnLayout.swift
+++ b/Orchard/Views/Layout/ThreeColumnLayout.swift
@@ -393,6 +393,11 @@ struct ThreeColumnLayout: View {
                     selectedClusterBinding: $selectedCluster,
                     selectedSandboxBinding: $selectedSandbox
                 )
+                // With the sidebar hidden this column is leftmost and the traffic
+                // lights float over it; inset below them, like the middle column's
+                // header does (#88). The middle-column layout never puts the detail
+                // leftmost, so only this arm needs it.
+                .padding(.top, sidebarCollapsed ? 52 : 0)
                 .ignoresSafeArea(.container, edges: .top)
             }
         }

--- a/scripts/orchard-ax.swift
+++ b/scripts/orchard-ax.swift
@@ -57,6 +57,7 @@ func matches(_ el: AXUIElement) -> Bool {
     if byText {
         return stringAttr(el, kAXValueAttribute as String) == wanted
             || stringAttr(el, kAXTitleAttribute as String) == wanted
+            || stringAttr(el, kAXDescriptionAttribute as String) == wanted
     }
     return identifier(el) == wanted
 }


### PR DESCRIPTION
## What does this PR do?

With the sidebar hidden, the detail-only pages (Dashboard, Registries, System Logs) become the window's leftmost column and their content renders underneath the macOS traffic lights. This applies the same conditional 52pt top inset the middle column has used since #49, in the two-column layout arm only — the three-column layout never puts the detail column leftmost, so it needs nothing.

The middle-column half of the report (Containers, Machines, Images, Mounts, DNS, Networks) was already fixed by #49 and shipped in 2.1.6; the report was filed against 2.1.5.

Also teaches the screenshot-tour helper to match toolbar buttons by accessibility description (used to drive Hide Sidebar for the verification).

## Related issues

Closes #88.

## Screenshots / recording

Verified live by toggling the sidebar on the Dashboard: the title and stat tiles now sit below the window controls instead of underneath them.

## Checklist

- [x] The project builds and runs (`Orchard` scheme)
- [x] Tests pass (`⌘U` / `xcodebuild test`) — 245 tests
- [x] I've added an entry to `CHANGELOG.md` (Added / Changed / Fixed)
- [x] The change is focused on a single logical concern