### PR TITLE
Add a preference to hide the Dock icon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Command palette: press Cmd+K (or View > Command Palette...) to fuzzy-search everything Orchard manages - containers, images, mounts, machines, k8s clusters, AI models, sandboxes, DNS domains and networks - and jump straight to any of them, or run actions from the keyboard: run a container, pull an image, create networks/machines/clusters, start/stop/restart the container system, and per-resource verbs like "stop db", "logs api" or "console web". Results rank with real fuzzy matching (exact prefix beats word-boundary beats scattered match); destructive operations are deliberately not palette-reachable.
+- The Dock icon can now be hidden (Settings > General > "Hide Dock icon"): Orchard switches to a menu-bar accessory, staying reachable from the menu bar, and the preference applies immediately and persists across launches. Note that macOS also removes accessory apps from the Cmd-Tab switcher.
 
 ### Fixed
 - The AI Models and Sandboxes middle columns no longer render lighter than every other list: they used the sidebar list style, which paints its own source-list background, instead of the plain style the rest of the middle columns use.

--- a/Orchard/OrchardApp.swift
+++ b/Orchard/OrchardApp.swift
@@ -6,6 +6,16 @@ struct OrchardApp: App {
     @StateObject private var menuBarManager = MenuBarManager()
     @StateObject private var updater = UpdaterService()
 
+    init() {
+        // Apply the persisted Dock-icon preference before any window appears. Read
+        // straight from defaults: the services aren't built yet. Only the hidden case
+        // needs applying - the app launches as .regular anyway, and applying .regular
+        // here would trigger the restore-activation dance at every launch.
+        if UserDefaults.standard.bool(forKey: SettingsStore.hideDockIconDefaultsKey) {
+            DockIconPolicy.apply(hidden: true)
+        }
+    }
+
     var body: some Scene {
         WindowGroup(id: "main") {
             ContentView()

--- a/Orchard/Services/DockIconPolicy.swift
+++ b/Orchard/Services/DockIconPolicy.swift
@@ -1,0 +1,26 @@
+import AppKit
+
+/// Applies the Dock-icon preference by switching the app's activation policy at runtime:
+/// `.accessory` hides the Dock icon (and removes the app from the Cmd-Tab switcher) while
+/// the menu-bar extra keeps the app reachable; `.regular` restores it. Runtime policy
+/// switching means the preference needs no relaunch, unlike `LSUIElement`.
+///
+/// Deliberately not a `SettingsStore` side effect: the store runs in unit tests on
+/// ephemeral defaults, and flipping the test runner's activation policy from a setter
+/// would be a nasty surprise. Callers (launch and the Settings toggle) apply it
+/// explicitly instead.
+@MainActor
+enum DockIconPolicy {
+    static func apply(hidden: Bool) {
+        // NSApplication.shared, not the NSApp global: at the launch call site (App.init)
+        // AppKit hasn't created the application object yet, so NSApp - an implicitly
+        // unwrapped optional - is still nil and would crash. Accessing .shared creates it.
+        let app = NSApplication.shared
+        app.setActivationPolicy(hidden ? .accessory : .regular)
+        if !hidden {
+            // Returning to .regular needs an explicit activation for the Dock icon and
+            // main menu to come back reliably - a long-standing AppKit quirk.
+            app.activate(ignoringOtherApps: true)
+        }
+    }
+}

--- a/Orchard/Services/SettingsStore.swift
+++ b/Orchard/Services/SettingsStore.swift
@@ -1,11 +1,16 @@
 import Foundation
 import AppKit
 
-/// Owns user settings: the `container` binary path and the preferred terminal.
+/// Owns user settings: the `container` binary path, the preferred terminal, and the
+/// Dock-icon preference.
 @MainActor
 final class SettingsStore: ObservableObject {
     @Published var customBinaryPath: String?
     @Published var preferredTerminal: TerminalApp = .terminal
+    /// Whether the app hides its Dock icon and runs as a menu-bar accessory. Persisted
+    /// here; the activation-policy side effect is applied by callers via
+    /// `DockIconPolicy` (see that type for why it isn't applied from the setter).
+    @Published private(set) var hideDockIcon: Bool = false
     @Published var installedTerminals: [TerminalApp] = [.terminal]
 
     private let alertCenter: AlertCenter
@@ -34,6 +39,9 @@ final class SettingsStore: ObservableObject {
     }
     private let customBinaryPathKey = "OrchardCustomBinaryPath"
     private let preferredTerminalKey = "OrchardPreferredTerminal"
+    /// Static so the app can read the launch policy straight from defaults before any
+    /// services are built.
+    static let hideDockIconDefaultsKey = "OrchardHideDockIcon"
 
     var containerBinaryPath: String {
         let path = customBinaryPath ?? defaultBinaryPath
@@ -51,6 +59,12 @@ final class SettingsStore: ObservableObject {
         self.defaults = defaults
         loadCustomBinaryPath()
         loadPreferredTerminal()
+        hideDockIcon = defaults.bool(forKey: Self.hideDockIconDefaultsKey)
+    }
+
+    func setHideDockIcon(_ hidden: Bool) {
+        hideDockIcon = hidden
+        defaults.set(hidden, forKey: Self.hideDockIconDefaultsKey)
     }
 
     private func loadCustomBinaryPath() {

--- a/Orchard/Views/Features/Settings/SettingsView.swift
+++ b/Orchard/Views/Features/Settings/SettingsView.swift
@@ -58,6 +58,19 @@ struct GeneralSettingsView: View {
             }
 
             Section {
+                Toggle("Hide Dock icon", isOn: Binding(
+                    get: { settings.hideDockIcon },
+                    set: { hidden in
+                        settings.setHideDockIcon(hidden)
+                        DockIconPolicy.apply(hidden: hidden)
+                    }
+                ))
+            } footer: {
+                Text("Orchard stays available from the menu bar. Hiding the Dock icon also removes Orchard from the Cmd-Tab app switcher; reopen the main window from the menu bar.")
+                    .foregroundColor(.secondary)
+            }
+
+            Section {
                 LabeledContent("Container Binary") {
                     HStack(spacing: 8) {
                         Text(settings.containerBinaryPath)

--- a/OrchardTests/SettingsStoreTests.swift
+++ b/OrchardTests/SettingsStoreTests.swift
@@ -140,3 +140,23 @@ func modelAPIKeyRoundTrip() {
         #expect(store.allModelAPIKeys().isEmpty)
     }
 }
+
+@MainActor
+@Test("Dock icon: defaults to visible, persists, and round-trips across store instances")
+func dockIconPreferencePersists() {
+    withSettingsStore { store, defaults in
+        #expect(store.hideDockIcon == false)
+
+        store.setHideDockIcon(true)
+        #expect(store.hideDockIcon == true)
+        #expect(defaults.bool(forKey: SettingsStore.hideDockIconDefaultsKey) == true)
+
+        // A fresh store on the same suite reads the persisted value back.
+        let second = SettingsStore(alertCenter: AlertCenter(), defaults: defaults, secrets: InMemorySecretsStore())
+        #expect(second.hideDockIcon == true)
+
+        second.setHideDockIcon(false)
+        #expect(second.hideDockIcon == false)
+        #expect(defaults.bool(forKey: SettingsStore.hideDockIconDefaultsKey) == false)
+    }
+}


### PR DESCRIPTION
## What

Settings > General gains a **"Hide Dock icon"** toggle. When enabled, Orchard switches its activation policy to `.accessory` at runtime: the Dock icon disappears, the app stays fully reachable from the menu-bar extra, and flipping the toggle back restores the icon immediately. No relaunch in either direction (runtime policy switching rather than `LSUIElement`). The preference persists in `SettingsStore` and is applied at launch in `OrchardApp.init`, before any window appears.

The footer text warns about the one macOS side effect users don't expect: accessory apps are also removed from the Cmd-Tab switcher.

## Design notes

- The activation-policy side effect lives in a small `DockIconPolicy` helper rather than the `SettingsStore` setter: the store runs in unit tests on ephemeral defaults, and a store side effect would flip the test runner's activation policy.
- `DockIconPolicy` uses `NSApplication.shared`, not the `NSApp` global: at the launch call site AppKit hasn't created the application object yet, so `NSApp` (an implicitly-unwrapped optional) is still nil and crashes. Caught in real-launch testing.
- Restoring `.regular` explicitly re-activates the app, working around the AppKit quirk where the Dock icon doesn't reliably come back otherwise.
- Launch only applies the hidden case: the app starts `.regular` anyway, and applying `.regular` would trigger the restore-activation dance on every launch.

## Testing

- 261 unit tests green, including a new `SettingsStore` persistence round-trip for the preference.
- Verified live: launched with the preference pre-set in defaults (starts as an accessory, no crash), and toggled both directions at runtime.
- One operational note: AppleScript `quit` can hang against an accessory-mode app, so the screenshot tour script should run with this preference off. Quit from the menu-bar extra is unaffected.