### PR TITLE
Add Pause button to the menu bar popup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- The menu bar popup now exposes a Stop control for the container system alongside the existing Start control, so the system can be shut down without opening the main window or going through the command palette. The button is gated on a running system and disabled while a transition is in flight; calling `stopSystem()` while a transition is already in flight is a no-op at the service layer.
+
 ### Fixed
 - Menu-bar System analytics no longer stays stuck on "Collecting…" when container stats fail. The menu-bar hover popover now distinguishes four explicit states: collecting during the initial two-tick baseline, available with real CPU/memory history, "No running containers" when the system has none to sample, and "Stats unavailable" with a short reason when the XPC service is unreachable or every stats call failed. Per-container stats failures are now logged via `Log.xpc` so diagnostics aren't blind, and the existing dashboard, container, and machine stats paths are unchanged. No new macOS permission is required.
 - Container service-unavailable failures in the menu-bar sampling tick are now logged only once per tick via `Log.xpc`; subsequent outcomes in the same tick fold in silently while the first error is retained, so a single tick with several unreachable containers no longer produces one log line per outcome.

--- a/Orchard.xcodeproj/xcshareddata/xcschemes/OrchardUITests.xcscheme
+++ b/Orchard.xcodeproj/xcshareddata/xcschemes/OrchardUITests.xcscheme
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
    LastUpgradeVersion = "2600"
-   version = "1.7">
+   version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES">
@@ -61,4 +61,18 @@
          </BuildableReference>
       </BuildableProductRunnable>
    </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
 </Scheme>

--- a/Orchard.xcodeproj/xcshareddata/xcschemes/OrchardUITests.xcscheme
+++ b/Orchard.xcodeproj/xcshareddata/xcschemes/OrchardUITests.xcscheme
@@ -9,9 +9,9 @@
          <BuildActionEntry
             buildForTesting = "YES"
             buildForRunning = "YES"
-            buildForProfiling = "NO"
-            buildForArchiving = "NO"
-            buildForAnalyzing = "NO">
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "C25FE6E62E00C69400A8CD32"
@@ -67,6 +67,16 @@
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
       debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "C25FE6E62E00C69400A8CD32"
+            BuildableName = "Orchard.app"
+            BlueprintName = "Orchard"
+            ReferencedContainer = "container:Orchard.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
    </ProfileAction>
    <AnalyzeAction
       buildConfiguration = "Debug">

--- a/Orchard/Services/SystemService.swift
+++ b/Orchard/Services/SystemService.swift
@@ -94,6 +94,7 @@ final class SystemService: ObservableObject {
     }
 
     func startSystem() async {
+        if isSystemLoading { return }
         isSystemLoading = true
         alertCenter.dismiss()
 
@@ -154,6 +155,7 @@ final class SystemService: ObservableObject {
     }
 
     func stopSystem() async {
+        if isSystemLoading { return }
         isSystemLoading = true
         alertCenter.dismiss()
 

--- a/Orchard/Services/SystemService.swift
+++ b/Orchard/Services/SystemService.swift
@@ -194,6 +194,7 @@ final class SystemService: ObservableObject {
     }
 
     func restartSystem() async {
+        if isSystemLoading { return }
         lifecycleGeneration &+= 1
         isSystemLoading = true
         alertCenter.dismiss()

--- a/Orchard/Services/SystemService.swift
+++ b/Orchard/Services/SystemService.swift
@@ -50,6 +50,11 @@ final class SystemService: ObservableObject {
     private let settings: SettingsStore
     private let alertCenter: AlertCenter
 
+    /// Bumped on every lifecycle call (start/stop/restart). A `checkSystemStatus`
+    /// pinged before the bump completes after it; its stale `.running` result would
+    /// otherwise overwrite the new `.stopped` state.
+    private var lifecycleGeneration: UInt64 = 0
+
     /// Refresh the container list after the system starts. Set by the owner.
     var onSystemStarted: () async -> Void = {}
     /// Clear the container list after the system stops. Set by the owner.
@@ -67,13 +72,19 @@ final class SystemService: ObservableObject {
     }
 
     func checkSystemStatus() async {
+        // Capture the generation at the start of the ping; if a lifecycle op bumps it
+        // while the ping is in flight, drop this stale result rather than overwrite
+        // the new state.
+        let generation = lifecycleGeneration
         do {
             let health = try await backend.ping()
+            guard lifecycleGeneration == generation else { return }
             self.containerVersion = health.apiServerVersion
             self.parsedContainerVersion = health.apiServerVersion
             self.systemStatus = .running
             self.systemStatusError = nil
         } catch {
+            guard lifecycleGeneration == generation else { return }
             self.containerVersion = nil
             self.parsedContainerVersion = nil
             // A health check the linked client can't decode isn't an outage: the daemon
@@ -95,6 +106,7 @@ final class SystemService: ObservableObject {
 
     func startSystem() async {
         if isSystemLoading { return }
+        lifecycleGeneration &+= 1
         isSystemLoading = true
         alertCenter.dismiss()
 
@@ -156,6 +168,7 @@ final class SystemService: ObservableObject {
 
     func stopSystem() async {
         if isSystemLoading { return }
+        lifecycleGeneration &+= 1
         isSystemLoading = true
         alertCenter.dismiss()
 
@@ -181,6 +194,7 @@ final class SystemService: ObservableObject {
     }
 
     func restartSystem() async {
+        lifecycleGeneration &+= 1
         isSystemLoading = true
         alertCenter.dismiss()
 

--- a/Orchard/Views/Features/MenuBar/MenuBarDashboard.swift
+++ b/Orchard/Views/Features/MenuBar/MenuBarDashboard.swift
@@ -399,7 +399,12 @@ struct MenuBarView: View {
         refreshTimer?.invalidate()
         refreshTimer = Timer.scheduledTimer(withTimeInterval: 5.0, repeats: true) { _ in
             Task { @MainActor in
-                await systemService.checkSystemStatus()
+                // A start/stop click owns `systemStatus` while it's in flight; skip the
+                // status refresh so a stale ping started before the click doesn't land
+                // after `.stopped` and flip the state back to `.running`.
+                if !systemService.isSystemLoading {
+                    await systemService.checkSystemStatus()
+                }
                 await containerListService.loadContainers(showLoading: false)
                 await builderService.loadBuilders()
                 await dnsService.load(showLoading: false)

--- a/Orchard/Views/Features/MenuBar/MenuBarDashboard.swift
+++ b/Orchard/Views/Features/MenuBar/MenuBarDashboard.swift
@@ -160,7 +160,7 @@ struct MenuBarView: View {
                 .font(.callout)
             }
 
-            // Only surface system status when it's stopped — with a way to start it.
+            // Surface a system control whenever the status is actionable: Start when stopped, Pause when running.
             if systemService.systemStatus == .stopped {
                 card {
                     HStack(spacing: 8) {
@@ -169,6 +169,18 @@ struct MenuBarView: View {
                         Spacer()
                         Button("Start") {
                             Task { @MainActor in await systemService.startSystem() }
+                        }
+                        .disabled(systemService.isSystemLoading)
+                    }
+                }
+            } else if systemService.systemStatus == .running {
+                card {
+                    HStack(spacing: 8) {
+                        Circle().fill(systemService.systemStatus.color).frame(width: 8, height: 8)
+                        Text("Containers is running").font(.subheadline)
+                        Spacer()
+                        Button("Pause") {
+                            Task { @MainActor in await systemService.stopSystem() }
                         }
                         .disabled(systemService.isSystemLoading)
                     }

--- a/Orchard/Views/Features/MenuBar/MenuBarDashboard.swift
+++ b/Orchard/Views/Features/MenuBar/MenuBarDashboard.swift
@@ -160,7 +160,7 @@ struct MenuBarView: View {
                 .font(.callout)
             }
 
-            // Surface a system control whenever the status is actionable: Start when stopped, Pause when running.
+            // Surface a system control whenever the status is actionable: Start when stopped, Stop when running.
             if systemService.systemStatus == .stopped {
                 card {
                     HStack(spacing: 8) {
@@ -179,7 +179,7 @@ struct MenuBarView: View {
                         Circle().fill(systemService.systemStatus.color).frame(width: 8, height: 8)
                         Text("Containers is running").font(.subheadline)
                         Spacer()
-                        Button("Pause") {
+                        Button("Stop") {
                             Task { @MainActor in await systemService.stopSystem() }
                         }
                         .disabled(systemService.isSystemLoading)

--- a/OrchardTests/MenuBarStopButtonTests.swift
+++ b/OrchardTests/MenuBarStopButtonTests.swift
@@ -1,0 +1,104 @@
+import Testing
+import Foundation
+@testable import Orchard
+
+// Tests for the Stop control surfaced in the menu bar popup
+// (Orchard/Views/Features/MenuBar/MenuBarDashboard.swift). The button is wired to
+// SystemService.stopSystem(); these tests exercise that contract end-to-end through
+// AppServices so they pick up the cross-service callbacks installed in AppServices.init
+// (clearing the container list via onSystemStopped).
+
+@MainActor
+@Test("stopSystem: success transitions to .stopped, clears isSystemLoading, issues exactly `system stop`")
+func stopSystemSuccess() async {
+    let runner = MockCommandRunner()   // default: exit 0
+    let backend = MockContainerBackend()
+    let service = makeService(backend: backend, runner: runner)
+
+    // Pre-condition: the menu bar's Stop branch is gated on .running.
+    service.systemService.systemStatus = .running
+    // Seed a container so the onSystemStopped side-effect has something to clear.
+    backend.containers = (try? [makeContainer(id: "web", status: "running")]) ?? []
+    await service.containerListService.loadContainers()
+    #expect(service.containerListService.containers.contains { $0.configuration.id == "web" })
+
+    await service.systemService.stopSystem()
+
+    #expect(service.systemService.systemStatus == .stopped)
+    #expect(service.systemService.isSystemLoading == false)
+    #expect(service.alertCenter.current == nil)
+    #expect(runner.calls == [["system", "stop"]])
+    // onSystemStopped hook installed by AppServices clears the in-memory container list.
+    #expect(service.containerListService.containers.isEmpty)
+}
+
+@MainActor
+@Test("stopSystem: isSystemLoading is true for the duration of the call")
+func stopSystemTogglesLoadingFlag() async {
+    let runner = MockCommandRunner()
+    var observedLoading = false
+    runner.runHandler = { _, _ in
+        observedLoading = true   // set so we can assert later that the handler ran
+        return ProcessResult(exitCode: 0, stdout: "", stderr: nil)
+    }
+    let service = makeService(runner: runner)
+    service.systemService.systemStatus = .running
+
+    await service.systemService.stopSystem()
+
+    #expect(observedLoading == true)              // the handler was actually invoked
+    #expect(service.systemService.isSystemLoading == false)   // flag cleared after the call
+}
+
+@MainActor
+@Test("stopSystem: thrown error surfaces an alert and re-derives status from the daemon")
+func stopSystemThrownErrorAlertsAndReDerives() async {
+    // Mirrors the existing stopSystemFailureReDerives case, but for the throw branch
+    // (runner throws) rather than the nonzero-exit branch. The menu bar's Stop button
+    // must not silently swallow either failure mode.
+    let runner = MockCommandRunner()
+    runner.runHandler = { _, _ in throw makeError("container CLI missing") }
+    let backend = MockContainerBackend()   // ping succeeds → daemon still running
+    let service = makeService(backend: backend, runner: runner)
+
+    await service.systemService.stopSystem()
+
+    #expect(service.systemService.systemStatus == .running)   // not force-set to .stopped
+    #expect(service.systemService.isSystemLoading == false)
+    #expect(service.alertCenter.current != nil)
+}
+
+@MainActor
+@Test("stopSystem: a second call while the first is in flight does not re-invoke the CLI")
+func stopSystemGuardsAgainstDoubleDispatch() async {
+    // Drive the runner to hang on a semaphore so we can issue a second stopSystem()
+    // while the first is still pending, and confirm the runner was only called once.
+    // The menu bar Stop button is `.disabled(isSystemLoading)`, but the service's
+    // own isSystemLoading short-circuit is the underlying guard against duplicate
+    // dispatch — useful for any future caller that bypasses the view layer.
+    let runner = MockCommandRunner()
+    let hang = DispatchSemaphore(value: 0)
+    var invocations = 0
+    runner.runHandler = { _, _ in
+        invocations += 1
+        hang.wait()   // blocks the runner until the test releases it
+        return ProcessResult(exitCode: 0, stdout: "", stderr: nil)
+    }
+    let service = makeService(runner: runner)
+    service.systemService.systemStatus = .running
+
+    let first = Task { @MainActor in await service.systemService.stopSystem() }
+    // Yield to let the first task reach the runner's blocking wait.
+    await Task.yield()
+    await Task.yield()
+    #expect(service.systemService.isSystemLoading == true)
+
+    // Second call should be a no-op while isSystemLoading is true.
+    await service.systemService.stopSystem()
+
+    #expect(invocations == 1)
+    #expect(runner.calls == [["system", "stop"]])
+
+    hang.signal()   // release the first task so the test can complete
+    await first.value
+}

--- a/OrchardTests/MenuBarStopButtonTests.swift
+++ b/OrchardTests/MenuBarStopButtonTests.swift
@@ -36,18 +36,33 @@ func stopSystemSuccess() async {
 @Test("stopSystem: isSystemLoading is true for the duration of the call")
 func stopSystemTogglesLoadingFlag() async {
     let runner = MockCommandRunner()
-    var observedLoading = false
-    runner.runHandler = { _, _ in
-        observedLoading = true   // set so we can assert later that the handler ran
-        return ProcessResult(exitCode: 0, stdout: "", stderr: nil)
-    }
     let service = makeService(runner: runner)
     service.systemService.systemStatus = .running
 
+    let observed = LockedBox<Bool?>(nil)
+    runner.runHandler = { _, _ in
+        // The CLI handler runs off the main actor; capture the loading flag by
+        // scheduling a main-actor hop. The assignment is awaited so the test can
+        // safely read `observed.value` after `stopSystem()` returns.
+        MainActor.assumeIsolated {
+            observed.set(service.systemService.isSystemLoading)
+        }
+        return ProcessResult(exitCode: 0, stdout: "", stderr: nil)
+    }
+
     await service.systemService.stopSystem()
 
-    #expect(observedLoading == true)              // the handler was actually invoked
+    #expect(observed.value == true)               // handler ran while loading flag was set
     #expect(service.systemService.isSystemLoading == false)   // flag cleared after the call
+}
+
+/// Locked box for one observation captured by a `@Sendable` test handler.
+private final class LockedBox<T> {
+    private let lock = NSLock()
+    private var _value: T
+    var value: T { lock.withLock { _value } }
+    init(_ value: T) { self._value = value }
+    func set(_ value: T) { lock.withLock { self._value = value } }
 }
 
 @MainActor
@@ -101,4 +116,38 @@ func stopSystemGuardsAgainstDoubleDispatch() async {
 
     hang.signal()   // release the first task so the test can complete
     await first.value
+}
+
+@MainActor
+@Test("stopSystem: a stale in-flight checkSystemStatus ping doesn't flip .stopped back to .running")
+func stopSystemIgnoresStaleStatusPing() async {
+    // Simulates the menu-bar race: a 5s status-refresh tick starts a `checkSystemStatus`
+    // (a `backend.ping()`) before the user clicks Pause. While that ping is held in
+    // flight, Stop completes and transitions the state to .stopped. Releasing the ping
+    // afterwards must NOT let its stale `.running` result overwrite .stopped.
+    let runner = MockCommandRunner()
+    let backend = MockContainerBackend()
+    let pingStarted = DispatchSemaphore(value: 0)
+    let releasePing = DispatchSemaphore(value: 0)
+    backend.pingHandler = {
+        pingStarted.signal()
+        releasePing.wait()
+        return SystemHealthInfo(apiServerVersion: "test")
+    }
+    let service = makeService(backend: backend, runner: runner)
+    service.systemService.systemStatus = .running
+
+    // Kick off the stale check and let it reach the held ping.
+    let checkTask = Task { @MainActor in await service.systemService.checkSystemStatus() }
+    pingStarted.wait()   // confirm the ping is actually in flight before we Stop
+
+    // Stop completes synchronously here (default MockCommandRunner returns success).
+    await service.systemService.stopSystem()
+    #expect(service.systemService.systemStatus == .stopped)
+
+    // Release the held ping; the stale check resumes and would otherwise re-set .running.
+    releasePing.signal()
+    await checkTask.value
+
+    #expect(service.systemService.systemStatus == .stopped)
 }

--- a/OrchardTests/MenuBarStopButtonTests.swift
+++ b/OrchardTests/MenuBarStopButtonTests.swift
@@ -151,7 +151,7 @@ func stopSystemGuardsAgainstDoubleDispatch() async {
 @Test("stopSystem: a stale in-flight checkSystemStatus ping doesn't flip .stopped back to .running")
 func stopSystemIgnoresStaleStatusPing() async {
     // Simulates the menu-bar race: a 5s status-refresh tick starts a `checkSystemStatus`
-    // (a `backend.ping()`) before the user clicks Pause. While that ping is held in
+    // (a `backend.ping()`) before the user clicks Stop. While that ping is held in
     // flight, Stop completes and transitions the state to .stopped. Releasing the ping
     // afterwards must NOT let its stale `.running` result overwrite .stopped.
     let runner = MockCommandRunner()

--- a/OrchardTests/MenuBarStopButtonTests.swift
+++ b/OrchardTests/MenuBarStopButtonTests.swift
@@ -41,10 +41,10 @@ func stopSystemTogglesLoadingFlag() async {
 
     let observed = LockedBox<Bool?>(nil)
     runner.runHandler = { _, _ in
-        // The CLI handler runs off the main actor; capture the loading flag by
-        // scheduling a main-actor hop. The assignment is awaited so the test can
-        // safely read `observed.value` after `stopSystem()` returns.
-        MainActor.assumeIsolated {
+        // The CLI handler runs off the main actor; capture the loading flag via an
+        // awaited main-actor hop so the test can safely read `observed.value` after
+        // `stopSystem()` returns.
+        await MainActor.run {
             observed.set(service.systemService.isSystemLoading)
         }
         return ProcessResult(exitCode: 0, stdout: "", stderr: nil)
@@ -63,6 +63,36 @@ private final class LockedBox<T> {
     var value: T { lock.withLock { _value } }
     init(_ value: T) { self._value = value }
     func set(_ value: T) { lock.withLock { self._value = value } }
+}
+
+/// A one-shot awaitable gate for tests: `wait()` suspends without blocking a thread until
+/// `open()` is called. Once open, later `wait()`s return immediately. Replaces the
+/// semaphore pattern, whose blocking waits are unsafe in `@MainActor` async tests.
+private final class TestGate: @unchecked Sendable {
+    private let lock = NSLock()
+    private var isOpen = false
+    private var waiters: [CheckedContinuation<Void, Never>] = []
+
+    func wait() async {
+        await withCheckedContinuation { continuation in
+            let resumeNow = lock.withLock { () -> Bool in
+                if isOpen { return true }
+                waiters.append(continuation)
+                return false
+            }
+            if resumeNow { continuation.resume() }
+        }
+    }
+
+    func open() {
+        let pending = lock.withLock { () -> [CheckedContinuation<Void, Never>] in
+            isOpen = true
+            let pending = waiters
+            waiters.removeAll()
+            return pending
+        }
+        pending.forEach { $0.resume() }
+    }
 }
 
 @MainActor
@@ -127,11 +157,11 @@ func stopSystemIgnoresStaleStatusPing() async {
     // afterwards must NOT let its stale `.running` result overwrite .stopped.
     let runner = MockCommandRunner()
     let backend = MockContainerBackend()
-    let pingStarted = DispatchSemaphore(value: 0)
-    let releasePing = DispatchSemaphore(value: 0)
+    let pingStarted = TestGate()
+    let releasePing = TestGate()
     backend.pingHandler = {
-        pingStarted.signal()
-        releasePing.wait()
+        pingStarted.open()
+        await releasePing.wait()
         return SystemHealthInfo(apiServerVersion: "test")
     }
     let service = makeService(backend: backend, runner: runner)
@@ -139,14 +169,14 @@ func stopSystemIgnoresStaleStatusPing() async {
 
     // Kick off the stale check and let it reach the held ping.
     let checkTask = Task { @MainActor in await service.systemService.checkSystemStatus() }
-    pingStarted.wait()   // confirm the ping is actually in flight before we Stop
+    await pingStarted.wait()   // confirm the ping is actually in flight before we Stop
 
     // Stop completes synchronously here (default MockCommandRunner returns success).
     await service.systemService.stopSystem()
     #expect(service.systemService.systemStatus == .stopped)
 
     // Release the held ping; the stale check resumes and would otherwise re-set .running.
-    releasePing.signal()
+    releasePing.open()
     await checkTask.value
 
     #expect(service.systemService.systemStatus == .stopped)

--- a/OrchardTests/MenuBarStopButtonTests.swift
+++ b/OrchardTests/MenuBarStopButtonTests.swift
@@ -116,35 +116,34 @@ func stopSystemThrownErrorAlertsAndReDerives() async {
 @MainActor
 @Test("stopSystem: a second call while the first is in flight does not re-invoke the CLI")
 func stopSystemGuardsAgainstDoubleDispatch() async {
-    // Drive the runner to hang on a semaphore so we can issue a second stopSystem()
-    // while the first is still pending, and confirm the runner was only called once.
-    // The menu bar Stop button is `.disabled(isSystemLoading)`, but the service's
-    // own isSystemLoading short-circuit is the underlying guard against duplicate
-    // dispatch — useful for any future caller that bypasses the view layer.
+    // Hold the runner on a gate so we can issue a second stopSystem() while the first
+    // is still pending, and confirm the runner was only called once. The menu bar Stop
+    // button is `.disabled(isSystemLoading)`, but the service's own isSystemLoading
+    // short-circuit is the underlying guard against duplicate dispatch — useful for
+    // any future caller that bypasses the view layer.
     let runner = MockCommandRunner()
-    let hang = DispatchSemaphore(value: 0)
-    var invocations = 0
+    let handlerEntered = TestGate()
+    let releaseRunner = TestGate()
     runner.runHandler = { _, _ in
-        invocations += 1
-        hang.wait()   // blocks the runner until the test releases it
+        handlerEntered.open()
+        await releaseRunner.wait()   // holds the runner until the test releases it
         return ProcessResult(exitCode: 0, stdout: "", stderr: nil)
     }
     let service = makeService(runner: runner)
     service.systemService.systemStatus = .running
 
     let first = Task { @MainActor in await service.systemService.stopSystem() }
-    // Yield to let the first task reach the runner's blocking wait.
-    await Task.yield()
-    await Task.yield()
+    // Suspends until the first task is actually inside the runner — no yield guessing.
+    // isSystemLoading was set before the runner await, and the call is already recorded.
+    await handlerEntered.wait()
     #expect(service.systemService.isSystemLoading == true)
 
     // Second call should be a no-op while isSystemLoading is true.
     await service.systemService.stopSystem()
 
-    #expect(invocations == 1)
     #expect(runner.calls == [["system", "stop"]])
 
-    hang.signal()   // release the first task so the test can complete
+    releaseRunner.open()   // release the first task so the test can complete
     await first.value
 }
 

--- a/OrchardTests/Mocks.swift
+++ b/OrchardTests/Mocks.swift
@@ -20,14 +20,14 @@ func makeError(_ message: String) -> NSError {
 final class MockCommandRunner: CommandRunner, @unchecked Sendable {
     private let lock = NSLock()
     private var _defaultResult = ProcessResult(exitCode: 0, stdout: "", stderr: nil)
-    private var _runHandler: (@Sendable (String, [String]) throws -> ProcessResult)?
+    private var _runHandler: (@Sendable (String, [String]) async throws -> ProcessResult)?
     private var _calls: [[String]] = []
 
     var defaultResult: ProcessResult {
         get { lock.withLock { _defaultResult } }
         set { lock.withLock { _defaultResult = newValue } }
     }
-    var runHandler: (@Sendable (String, [String]) throws -> ProcessResult)? {
+    var runHandler: (@Sendable (String, [String]) async throws -> ProcessResult)? {
         get { lock.withLock { _runHandler } }
         set { lock.withLock { _runHandler = newValue } }
     }
@@ -35,7 +35,7 @@ final class MockCommandRunner: CommandRunner, @unchecked Sendable {
 
     func run(program: String, arguments: [String]) async throws -> ProcessResult {
         lock.withLock { _calls.append(arguments) }
-        if let handler = runHandler { return try handler(program, arguments) }
+        if let handler = runHandler { return try await handler(program, arguments) }
         return defaultResult
     }
 

--- a/OrchardTests/Mocks.swift
+++ b/OrchardTests/Mocks.swift
@@ -65,6 +65,7 @@ final class MockContainerBackend: ContainerBackend, @unchecked Sendable {
     private var _deleteContainerError: Error?
     private var _pingError: Error?
     private var _pingCount = 0
+    private var _pingHandler: (@Sendable () async throws -> SystemHealthInfo)?
     private var _bootstrapAndStartHandler: (@Sendable (Int) throws -> Void)?
     private var _statsHandler: (@Sendable (String) throws -> Orchard.ContainerStats)?
 
@@ -140,6 +141,12 @@ final class MockContainerBackend: ContainerBackend, @unchecked Sendable {
     }
     /// Number of `ping()` calls, for asserting how often a poll retried.
     var pingCount: Int { lock.withLock { _pingCount } }
+    /// Test-supplied ping handler. When set, takes over from the default success/throw
+    /// path so a test can hold the ping in flight across a lifecycle op.
+    var pingHandler: (@Sendable () async throws -> SystemHealthInfo)? {
+        get { lock.withLock { _pingHandler } }
+        set { lock.withLock { _pingHandler = newValue } }
+    }
     /// Called with the 1-based attempt count; throw to simulate a failed start.
     var bootstrapAndStartHandler: (@Sendable (Int) throws -> Void)? {
         get { lock.withLock { _bootstrapAndStartHandler } }
@@ -217,6 +224,9 @@ final class MockContainerBackend: ContainerBackend, @unchecked Sendable {
     }
     func ping() async throws -> SystemHealthInfo {
         lock.withLock { _pingCount += 1 }
+        if let handler = lock.withLock({ _pingHandler }) {
+            return try await handler()
+        }
         if let pingError { throw pingError }
         return SystemHealthInfo(apiServerVersion: "test")
     }


### PR DESCRIPTION
## What does this PR do?

 The menu bar popup surfaces a Start control when the container system is stopped, but offers nothing when it's running — shutting the system down meant opening the main window or finding the command palette. This PR adds a symmetric Stop control to the menu bar popup, gated on a running system and disabled while a transition is in flight.

 While writing tests I noticed the service itself had no defence against duplicate dispatches: the only thing preventing two container system stop invocations was the view layer's .disabled(isSystemLoading). Move that guard down into SystemService so the service is the canonical owner of the "operation in flight" invariant startSystem() and stopSystem() now both early-return when isSystemLoading is already true. Future callers that bypass the menu bar (e.g. a command-palette action, a future menu item) get the same guarantee for free.

##  Related issues

N/A

## Screenshots / recording

BEFORE:

<img width="326" height="197" alt="Screenshot 2026-08-21 at 23 33 00" src="https://github.com/user-attachments/assets/e7670589-7917-47b1-8d0a-b4fd7c154679" />


AFTER:

<img width="326" height="249" alt="Screenshot 2026-08-21 at 23 32 35" src="https://github.com/user-attachments/assets/28d51ad5-a983-444c-8290-6f6976f16854" />


##  Checklist

- [x] The project builds and runs (`Orchard` scheme)
- [x] Tests pass (`⌘U` / `xcodebuild test`)
- [x] I've added an entry to `CHANGELOG.md` (Added / Changed / Fixed)
- [x] The change is focused on a single logical concern