### PR TITLE
Stop model-provider probes from following redirects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Local-model detection no longer follows HTTP redirects when probing for providers. The probe targets conventional ports (11434, 1234, 8080, 8000), which are often owned by something else entirely; a dev server on 8080 that redirects to its TLS port would take the probe with it, so Orchard opened a connection to an unrelated endpoint every five seconds and abandoned it when the 1.5s probe deadline expired. Against a Rails app running with `force_ssl` this leaked a socket per probe until the server's accept loop stopped and it served nothing at all. A real provider answers 200 directly, so a redirect is now simply classified as "not a provider" - which also stops a redirecting server from being misreported as a model server.
+
 ## [2.2.2] - 2026-08-25
 
 ### Added

--- a/Orchard/Services/ModelBackend.swift
+++ b/Orchard/Services/ModelBackend.swift
@@ -63,6 +63,25 @@ protocol ModelBackend: Sendable {
 
 // MARK: - Live implementation
 
+/// Refuses every HTTP redirect. Probes aim at conventional ports, which are routinely
+/// owned by something other than a model server - an ordinary dev server on 8080 will
+/// happily 301 the probe onto another port or host. Following that spends the 1.5s probe
+/// deadline on an unrelated endpoint and, when it expires, abandons a half-finished
+/// connection there. A real provider answers 200 directly, so a redirect means no more
+/// than "not a provider". Stateless, hence safe to share across concurrent probes.
+private final class ProbeRedirectBlocker: NSObject, URLSessionTaskDelegate, @unchecked Sendable {
+    func urlSession(
+        _ session: URLSession,
+        task: URLSessionTask,
+        willPerformHTTPRedirection response: HTTPURLResponse,
+        newRequest request: URLRequest
+    ) async -> URLRequest? {
+        nil
+    }
+}
+
+private let probeRedirectBlocker = ProbeRedirectBlocker()
+
 /// `ModelBackend` that discovers providers by probing their conventional loopback ports
 /// over HTTP. An unreachable port simply means "that provider isn't running."
 struct LiveModelBackend: ModelBackend {
@@ -104,14 +123,16 @@ struct LiveModelBackend: ModelBackend {
         }
     }
 
-    private static func probe(_ candidate: Candidate, session: URLSession, apiKey: String?) async -> ModelProvider? {
+    /// Probe one candidate. Non-private so the redirect and classification behaviour is
+    /// testable against a stub transport.
+    static func probe(_ candidate: Candidate, session: URLSession, apiKey: String?) async -> ModelProvider? {
         guard let url = URL(string: "http://127.0.0.1:\(candidate.port)\(candidate.listPath)") else { return nil }
         var request = URLRequest(url: url)
         request.timeoutInterval = 1.5
         if let apiKey {
             request.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
         }
-        guard let (data, response) = try? await session.data(for: request),
+        guard let (data, response) = try? await session.data(for: request, delegate: probeRedirectBlocker),
               let http = response as? HTTPURLResponse else {
             return nil
         }

--- a/OrchardTests/ModelBridgeTests.swift
+++ b/OrchardTests/ModelBridgeTests.swift
@@ -119,7 +119,8 @@ func probeClassifiesLocked(status: Int) {
     #expect(provider?.kind == .mlxServer)   // can't refine without a listing
 }
 
-@Test("Probe: other statuses are not a provider", arguments: [404, 500, 302])
+@Test("Probe: other statuses - redirects included - are not a provider",
+      arguments: [404, 500, 301, 302, 307, 308])
 func probeClassifiesOther(status: Int) {
     #expect(LiveModelBackend.provider(from: status, data: Data(), candidate: omlxCandidate) == nil)
 }
@@ -131,4 +132,112 @@ func bridgeEnvWithKey() {
 
     let open = ModelBridge.injectionEnvironment(baseURL: "http://192.168.64.1:8000/v1", api: .openAI)
     #expect(open.contains { $0.key == "OPENAI_API_KEY" && $0.value == "not-needed" })
+}
+
+// MARK: - Probe transport (redirects are not followed)
+
+/// Canned transport for probe tests. Replies from a per-URL script and records every URL
+/// the session asks for, so a test can assert what was *not* requested. Redirects are
+/// announced via `wasRedirectedTo:` so the session's real redirect machinery - and hence
+/// the task delegate - is exercised, rather than the 3xx being handed back as a plain
+/// response.
+final class ProbeStubProtocol: URLProtocol, @unchecked Sendable {
+    struct Reply: Sendable {
+        var status: Int
+        var location: String?
+        var body: Data = Data()
+    }
+
+    private static let lock = NSLock()
+    nonisolated(unsafe) private static var script: [String: Reply] = [:]
+    nonisolated(unsafe) private static var requested: [String] = []
+
+    /// Installs `script` (keyed by absolute URL) and returns a session wired to this stub.
+    static func session(script: [String: Reply]) -> URLSession {
+        lock.lock()
+        self.script = script
+        requested = []
+        lock.unlock()
+
+        let config = URLSessionConfiguration.ephemeral
+        config.protocolClasses = [ProbeStubProtocol.self]
+        return URLSession(configuration: config)
+    }
+
+    static var requestedURLs: [String] {
+        lock.lock()
+        defer { lock.unlock() }
+        return requested
+    }
+
+    override class func canInit(with request: URLRequest) -> Bool { true }
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+    override func stopLoading() {}
+
+    override func startLoading() {
+        guard let url = request.url else { return }
+
+        Self.lock.lock()
+        Self.requested.append(url.absoluteString)
+        let reply = Self.script[url.absoluteString] ?? Reply(status: 404)
+        Self.lock.unlock()
+
+        var headers: [String: String] = [:]
+        if let location = reply.location { headers["Location"] = location }
+        guard let response = HTTPURLResponse(
+            url: url, statusCode: reply.status, httpVersion: "HTTP/1.1", headerFields: headers
+        ) else {
+            client?.urlProtocolDidFinishLoading(self)
+            return
+        }
+
+        if let location = reply.location, let next = URL(string: location) {
+            client?.urlProtocol(self, wasRedirectedTo: URLRequest(url: next), redirectResponse: response)
+            // Also complete the task. A refused redirect otherwise leaves this protocol
+            // instance loading until the request deadline, which would make the test spend
+            // the probe's full timeout proving a point about the delegate.
+        }
+
+        client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+        client?.urlProtocol(self, didLoad: reply.body)
+        client?.urlProtocolDidFinishLoading(self)
+    }
+}
+
+private let mlx8080 = LiveModelBackend.Candidate(kind: .mlxServer, port: 8080, api: .openAI, listPath: "/v1/models")
+
+/// Serialized: the stub keeps its script and its request log in static state.
+@Suite("Probe transport", .serialized)
+struct ProbeTransportTests {
+    /// The shape that froze a Rails dev server: an app on 8080 running with `force_ssl`
+    /// redirects the probe to its TLS port, which answers something that parses as a model
+    /// listing. The probe must stop at the redirect and never open the second connection.
+    @Test("Probe: a redirect is refused, so the target is never requested")
+    func probeDoesNotFollowRedirect() async {
+        let listing = Data(#"{"object":"list","data":[{"id":"not-a-model-server"}]}"#.utf8)
+        let session = ProbeStubProtocol.session(script: [
+            "http://127.0.0.1:8080/v1/models": .init(status: 301, location: "https://127.0.0.1:8443/v1/models"),
+            "https://127.0.0.1:8443/v1/models": .init(status: 200, body: listing),
+        ])
+
+        let provider = await LiveModelBackend.probe(mlx8080, session: session, apiKey: nil)
+
+        #expect(provider == nil)
+        #expect(ProbeStubProtocol.requestedURLs == ["http://127.0.0.1:8080/v1/models"])
+    }
+
+    /// Guards the test above: without this, a stub that never serves anything would make
+    /// the redirect assertion pass for the wrong reason.
+    @Test("Probe: a 200 listing on the candidate port is a provider")
+    func probeAcceptsDirectListing() async {
+        let listing = Data(#"{"object":"list","data":[{"id":"qwen3-4b"}]}"#.utf8)
+        let session = ProbeStubProtocol.session(script: [
+            "http://127.0.0.1:8080/v1/models": .init(status: 200, body: listing),
+        ])
+
+        let provider = await LiveModelBackend.probe(mlx8080, session: session, apiKey: nil)
+
+        #expect(provider?.models == ["qwen3-4b"])
+        #expect(ProbeStubProtocol.requestedURLs == ["http://127.0.0.1:8080/v1/models"])
+    }
 }


### PR DESCRIPTION
## What

Local-model detection no longer follows HTTP redirects when probing for
providers. A redirect is now classified as "not a provider".

## Why

`LiveModelBackend.detectProviders` probes conventional ports — 11434, 1234,
8080, 8000 — every five seconds from the refresh tick. Those ports are
regularly occupied by something that isn't a model server, and
`URLSession` follows redirects by default. So the probe could be walked
somewhere else entirely.

Concretely, against a Rails app on 8080 running with `force_ssl`:

1. `GET http://127.0.0.1:8080/v1/models`
2. → `301 https://127.0.0.1:8443/v1/models` — probe dials the TLS port
3. → `302` to an unrelated public host — probe follows that too

That chain routinely exceeds the probe's `timeoutInterval = 1.5`, so
`URLSession` cancelled it and left a half-finished connection on each hop.
At twelve probes a minute the Rails server accumulated abandoned sockets
until its accept loop stopped: process alive, 0% CPU, every request timing
out, only a restart clearing it. Orchard was the only thing talking to it.

Two bugs, one cause. The probe also *misreported* the redirecting server as
a live `mlxServer`, because the body it eventually landed on happened to
parse as a model listing.

## How

A stateless `ProbeRedirectBlocker: URLSessionTaskDelegate` returning `nil`
from `willPerformHTTPRedirection`, passed to `session.data(for:delegate:)`.
No classifier change needed — `provider(from:)` already routes 3xx into
`default: return nil`.

## Testing

- `probeClassifiesOther` extended from `[404, 500, 302]` to
  `[404, 500, 301, 302, 307, 308]`.
- New `ProbeStubProtocol`, a `URLProtocol` stub that scripts replies per URL
  and records every URL the session requests. It signals redirects through
  `urlProtocol(_:wasRedirectedTo:redirectResponse:)` so the session's real
  redirect machinery — and therefore the delegate — is exercised, rather
  than the 3xx being handed back as a plain response.
- `@Suite("Probe transport", .serialized)` — serialized because the stub
  holds static state — with the 8080 → 8443 reproduction plus a direct-200
  case guarding against the first passing for want of a working stub.

Confirmed the test discriminates by reverting the one-line fix and
re-running:

    ✘ Expectation failed: (ProbeStubProtocol.requestedURLs →
      ["http://127.0.0.1:8080/v1/models", "https://127.0.0.1:8443/v1/models"])
      == ["http://127.0.0.1:8080/v1/models"]
    ✘ Expectation failed: (provider → ModelProvider(kind: .mlxServer,
      port: 8080, models: ["not-a-model-server"], ...)) == nil

Full suite green with the fix in place: 281 tests in 4 suites passed.

No UI change, so no screenshots. CHANGELOG updated under `[Unreleased] /
Fixed`.

## Not in scope

There's still no setting to disable model detection, and the scan has no
backoff — port 8080 gets probed every five seconds forever whether or not
anything ever answers. Happy to file those separately.