### PR TITLE
Link Apple container 1.3.1 client libraries (previously 1.2.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- Orchard now links the Apple container 1.3.1 client libraries (previously 1.2.2), restoring compatibility with current container installs. 1.3.1 also patches six security advisories in the containerization package that Orchard's image operations link directly, including path traversal in the local content store and a `RegistryClient` that followed `WWW-Authenticate` realms without validating the host.
+- Image pulls now default to `https` for all registries, matching container 1.3.0's removal of the `auto` registry scheme. Pulls from localhost or private-IP registries no longer silently downgrade to plain http; a local http registry needs `registry.scheme = "http"` in the container configuration, same as the `container` CLI.
+
 ### Fixed
 - Local-model detection no longer follows HTTP redirects when probing for providers. The probe targets conventional ports (11434, 1234, 8080, 8000), which are often owned by something else entirely; a dev server on 8080 that redirects to its TLS port would take the probe with it, so Orchard opened a connection to an unrelated endpoint every five seconds and abandoned it when the 1.5s probe deadline expired. Against a Rails app running with `force_ssl` this leaked a socket per probe until the server's accept loop stopped and it served nothing at all. A real provider answers 200 directly, so a redirect is now simply classified as "not a provider" - which also stops a redirecting server from being misreported as a model server.
 

--- a/Orchard.xcodeproj/project.pbxproj
+++ b/Orchard.xcodeproj/project.pbxproj
@@ -622,7 +622,7 @@
 			repositoryURL = "https://github.com/apple/container.git";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 1.2.2;
+				minimumVersion = 1.3.1;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/Orchard.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Orchard.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -15,8 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/container.git",
       "state" : {
-        "revision" : "0190097d06df0b9065f4c2d2c7873c649d81d493",
-        "version" : "1.2.2"
+        "revision" : "a9a62e28f6beb88940122a3d7b286f2d5ae8053a",
+        "version" : "1.3.1"
       }
     },
     {
@@ -24,8 +24,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/containerization.git",
       "state" : {
-        "revision" : "7800b4642171561c95b5f55500b19e5dce5acd45",
-        "version" : "0.40.1"
+        "revision" : "c0185aea5c04fcd4d1cfe9359e0066a380835403",
+        "version" : "0.42.0"
       }
     },
     {

--- a/Orchard/Services/ContainerBackend.swift
+++ b/Orchard/Services/ContainerBackend.swift
@@ -114,7 +114,7 @@ func mapContainerError(_ error: Error) -> Error {
 
 /// The apple/container release Orchard's client libraries are built against. Keep in
 /// sync with the container package pin in project.pbxproj when bumping.
-let supportedContainerVersion = "1.2.2"
+let supportedContainerVersion = "1.3.1"
 
 /// A ping reply the linked client cannot decode means the installed daemon speaks a
 /// different protocol revision than the client libraries Orchard links.


### PR DESCRIPTION
## What does this PR do?

Bumps the apple/container package pin from 1.2.2 to 1.3.1 (with containerization 0.42.0, the exact version it requires) and updates `supportedContainerVersion` to match, restoring compatibility with current container installs. Users on container 1.3.x currently hit the version-incompatibility screen.

1.3.1 is a security patch release fixing six advisories in the containerization package that Orchard links directly for image operations: path traversal in the local content store, symlink reads when loading OCI layouts, a `RegistryClient` that followed `WWW-Authenticate` realms without validating host or scheme (CVE-2026-65388), and two unpack crashes on crafted image layers.

Behavioral change inherited from container 1.3.0: the `auto` registry scheme was removed upstream, so image pulls now default to `https` for all registries. Orchard calls `ClientImage.pull`/`fetch` without a scheme argument, so no source change was needed, but pulls from localhost/private-IP registries no longer silently downgrade to plain http. A local http registry needs `registry.scheme = "http"` in the container config, matching the `container` CLI. Both changes are noted in the changelog.

## Related issues

None.

## Screenshots / recording

No UI change.

## Checklist

- [x] The project builds and runs (`Orchard` scheme)
- [x] Tests pass (`⌘U` / `xcodebuild test`): 281 tests, all passing
- [x] I've added an entry to `CHANGELOG.md` (Added / Changed / Fixed)
- [x] The change is focused on a single logical concern
