### PR TITLE
Compute full image sizes instead of manifest descriptor sizes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Image sizes now match `container image ls -v` (#98). Orchard was showing the size of each variant's manifest *descriptor* — a couple of kilobytes of JSON — instead of the image content, so every image listed as "1 KB"–"3 KB". Variant sizes are now computed the same way the CLI computes FULL SIZE: manifest descriptor plus config blob plus the sum of the compressed layers. The container detail's Image section and the multi-select image cards previously showed the raw index descriptor size as "Size"; both now use the same resolved size as the images list, and the image Technical Details row is relabeled "Index Size (bytes)" since that value genuinely is the index descriptor size.
+
 ## [2.3.0] - 2026-08-29
 
 ### Changed

--- a/Orchard/Services/ContainerBackend.swift
+++ b/Orchard/Services/ContainerBackend.swift
@@ -325,14 +325,21 @@ struct LiveContainerBackend: ContainerBackend {
             let index = try await image.index()
 
             var variants: [ImageInspection.Variant] = []
-            for manifest in index.manifests {
-                guard let platform = manifest.platform else { continue }
+            for manifestDescriptor in index.manifests {
+                guard let platform = manifestDescriptor.platform else { continue }
                 // Config blobs for non-local architectures may be absent; skip config
                 // details rather than failing the whole inspection.
                 let config = (try? await image.config(for: platform))?.config
+                // Full size matches `container image ls -v`: manifest descriptor plus
+                // config blob plus compressed layers. Manifest blobs for non-local
+                // architectures may be absent; those variants keep the descriptor size.
+                var size = manifestDescriptor.size
+                if let manifest = try? await image.manifest(for: platform) {
+                    size += manifest.config.size + manifest.layers.reduce(0) { $0 + $1.size }
+                }
                 variants.append(ImageInspection.Variant(
                     platform: "\(platform.os)/\(platform.architecture)",
-                    size: manifest.size,
+                    size: size,
                     entrypoint: config?.entrypoint,
                     cmd: config?.cmd,
                     env: config?.env,

--- a/Orchard/Services/ImageService.swift
+++ b/Orchard/Services/ImageService.swift
@@ -212,7 +212,11 @@ final class ImageService: ObservableObject {
     }
 
     func sizeText(for image: ContainerImage) -> String {
-        switch imageSizes[image.reference] {
+        sizeText(forReference: image.reference)
+    }
+
+    func sizeText(forReference reference: String) -> String {
+        switch imageSizes[reference] {
         case .known(let size):
             return ByteFormat.string(size)
         case .loading, .none:

--- a/Orchard/Views/Features/Containers/ContainerDetail.swift
+++ b/Orchard/Views/Features/Containers/ContainerDetail.swift
@@ -153,7 +153,7 @@ struct ContainerDetailView: View {
                 )
                 InfoRow(
                     label: "Size",
-                    value: ByteFormat.string(container.configuration.image.descriptor.size))
+                    value: imageService.sizeText(forReference: container.configuration.image.reference))
             }
         }
         .frame(maxWidth: .infinity, alignment: .leading)
@@ -617,7 +617,7 @@ struct ContainerImageDetailView: View {
                         image.descriptor.digest.replacingOccurrences(of: "sha256:", with: "")
                             .prefix(12))
                 )
-                InfoRow(label: "Size (bytes)", value: "\(image.descriptor.size)")
+                InfoRow(label: "Index Size (bytes)", value: "\(image.descriptor.size)")
             }
         }
     }

--- a/Orchard/Views/Features/Images/MultiImageCards.swift
+++ b/Orchard/Views/Features/Images/MultiImageCards.swift
@@ -78,7 +78,7 @@ private struct ImageSummaryCard: View {
     let onOpen: () -> Void
 
     private var sizeText: String {
-        ByteCountFormatter().string(fromByteCount: Int64(image.descriptor.size))
+        imageService.sizeText(for: image)
     }
 
     private var inUse: Bool {


### PR DESCRIPTION
## What does this PR do?

Fixes the image sizes shown across the GUI, which disagreed with `container image ls -v` by three orders of magnitude.

`inspectImage` set each variant's size to `manifest.size` — the size of the manifest *descriptor* in the OCI index, i.e. a couple of kilobytes of JSON — so every image listed as "1 KB"–"3 KB". Variant sizes are now computed the way the CLI computes FULL SIZE (see `ClientImage.toImageResource` in apple/container): manifest descriptor + config blob + the sum of the compressed layer sizes. When a non-local platform's manifest blob is absent from the content store, the variant falls back to the descriptor size as before; the size surfaced in the list and Overview picks the host platform's variant, whose blobs are always present.

Two views also rendered raw descriptor sizes as "Size" and are routed through the same resolved size (via a new `ImageService.sizeText(forReference:)`):

- the container detail's Image section
- the multi-select image summary cards

The image Technical Details row is relabeled "Index Size (bytes)", since that value genuinely is the index descriptor size and reading "Size (bytes): 1609" next to "Size: 58.1 MB" was confusing.

## Related issues

Closes #98

## Screenshots / recording

Before: see the screenshot in #98 (alpine "1 KB", node "2 KB", …).

After (verified against a live daemon): the Images list matches `container image ls -v` exactly — alpine 4.2 MB, caddy:alpine 22.7 MB, docker-ubuntu2204-ansible 291.3 MB, memcached:alpine 6.3 MB, nats:alpine 10.8 MB, nginx:alpine 26.2 MB.

## Checklist

- [x] The project builds and runs (`Orchard` scheme)
- [x] Tests pass (`⌘U` / `xcodebuild test`) — 281 tests, all passing
- [x] I've added an entry to `CHANGELOG.md` (Added / Changed / Fixed)
- [x] The change is focused on a single logical concern