### PR TITLE
Keep the system status poll alive while the system is stopped

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- The GUI now tracks the container system when it is stopped and started from the CLI (#100). The 5-second status poll was torn down by the main interface's `onDisappear`, which also fires when the system stops and the "not running" screen swaps in. After that, nothing polled, so a `container system start` run in a terminal was never noticed and Orchard stayed on "Container is not currently running" until the power button was clicked. The same dead end was reachable by launching Orchard while the system was stopped. The poll's lifetime now matches the window rather than one branch of the state view, so external stops appear within a poll tick (a stop can still lag while `container system stop` drains running containers, since the API server answers until it deregisters) and an external start restores the full interface automatically.
+
 ## [2.3.1] - 2026-08-30
 
 ### Fixed

--- a/Orchard/Views/Layout/Content.swift
+++ b/Orchard/Views/Layout/Content.swift
@@ -123,9 +123,6 @@ struct ContentView: View {
                 )
                 .navigationTitle("")
                 .toolbarBackgroundVisibility(.hidden, for: .windowToolbar)
-                .onDisappear {
-                    stopRefreshTimer()
-                }
             }
         }
     }
@@ -463,6 +460,13 @@ struct ContentView: View {
                 }
             }
             startRefreshTimer()
+        }
+        // The timer's lifetime must match the window, not one branch of `baseView`:
+        // tearing it down from MainInterfaceView.onDisappear killed polling the moment
+        // the system stopped and NotRunningView swapped in, so an external
+        // `container system start` was never noticed (#100).
+        .onDisappear {
+            stopRefreshTimer()
         }
         .onChange(of: selectedTab) { _, _ in
             // The filter box is shared across tabs; a query typed in one tab would


### PR DESCRIPTION
Fixes #100.

## Problem

Stopping and starting the container system from the CLI while Orchard is running is not reflected in the GUI.

The 5-second refresh timer is started by a `.task` on ContentView's outer view chain, but its teardown lived on `MainInterfaceView.onDisappear`, which fires not only on window close but also the moment the system stops and `baseView` swaps in `NotRunningView`. After that swap nothing polls at all: `NotRunningView` checks status exactly once in its `.task`, and the `onChange(of: systemStatus)` that restarts the timer only fires on a transition to `.running`, which can never happen with the poll dead. So an external `container system start` was never noticed and Orchard sat on "Container is not currently running" until the power button was clicked.

Launching Orchard while the system was stopped hit the same dead end: the initial `.unknown` state renders `MainInterfaceView`, and the first status check swapped it out, killing the timer that had just been started.

## Fix

Move `stopRefreshTimer()` from `MainInterfaceView.onDisappear` to the outer view chain, next to the `.task` that starts the timer, so the poll's lifetime matches the window rather than one branch of the state view. The tick is already safe to run in every state (it checks system status first and guards before hammering the other services), and the existing `onChange(of: systemStatus)` path performs the full initial load when an external start is detected. The one-shot checks on the NotRunning/NewerVersion/VersionIncompatibility screens are covered for free since the shared timer keeps running.

Note on the other direction: an external `container system stop` can still take a while to show up, because the CLI drains running containers (up to ~25s) before deregistering the API server, and health pings succeed until deregistration (verified against apple/container's `SystemStop` implementation). Once the API server is gone the next tick flips the UI, as before.

## Testing

- `xcodebuild build` passes locally; the change is view-lifecycle only (10 lines, no service changes), and views are deliberately outside unit-test coverage.
- Not yet manually verified against a live `container system stop`/`start` cycle. To verify per the issue: with the app open, run `container system stop` in a terminal. The GUI should show the not-running screen once the CLI finishes draining. Then `container system start` should return the GUI to the main interface within a poll tick (~5s), where previously it stayed stuck.
