### PR TITLE
Prevent Container Detail Scrolling From Hanging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
-- Scrolling a container's detail pane no longer hangs the app (#103). The six configuration wells sat in a `LazyVGrid`, and placing a row whose wells hold selectable text re-entered the grid's own placement: the main thread spun in over a thousand nested `sizeThatFits` frames at 100% CPU with memory climbing about 13 MB a second, and the window never recovered. The same two-column layout is now built eagerly from stacked rows, which six wells cost nothing to lay out up front. Long environment-variable and OCI-label keys also cap their column rather than sizing to the longest key without limit, so a namespaced key wraps instead of pushing the value and its Show/Copy controls out of the row.
+- Scrolling a container's detail pane no longer hangs the app (#103). The six configuration wells sat in a `LazyVGrid`, and placing a row whose wells hold selectable text re-entered the grid's own placement: the main thread spun in over a thousand nested `sizeThatFits` frames at 100% CPU with memory climbing about 13 MB a second, and the window never recovered. The same two-column layout is now built eagerly from stacked rows, which six wells cost nothing to lay out up front. The wells also pair up only while the pane is wide enough to carry two and stack below that: at a 1024-point window two columns left a key/value row so little width that its value and Show/Copy controls fell out of the row entirely. Long environment-variable and OCI-label keys additionally cap their column rather than sizing to the longest key without limit, so a namespaced key wraps instead of crowding out its own value.
 
 ## [2.3.3] - 2026-08-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
-- Container details now use a stable full-width configuration layout that prevents scrolling from hanging, while long environment-variable or label keys wrap within a bounded column instead of pushing values and controls off-screen.
+- Scrolling a container's detail pane no longer hangs the app (#103). The six configuration wells sat in a `LazyVGrid`, and placing a row whose wells hold selectable text re-entered the grid's own placement: the main thread spun in over a thousand nested `sizeThatFits` frames at 100% CPU with memory climbing about 13 MB a second, and the window never recovered. The same two-column layout is now built eagerly from stacked rows, which six wells cost nothing to lay out up front. Long environment-variable and OCI-label keys also cap their column rather than sizing to the longest key without limit, so a namespaced key wraps instead of pushing the value and its Show/Copy controls out of the row.
 
 ## [2.3.3] - 2026-08-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Container details now use a stable full-width configuration layout that prevents scrolling from hanging, while long environment-variable or label keys wrap within a bounded column instead of pushing values and controls off-screen.
+
 ## [2.3.3] - 2026-08-30
 
 ### Fixed

--- a/Orchard/Services/UITestSupport.swift
+++ b/Orchard/Services/UITestSupport.swift
@@ -30,7 +30,10 @@ struct UITestBackend: ContainerBackend {
                 runtimeHandler: "vm",
                 initProcess: initProcess(
                     terminal: false,
-                    environment: ["PATH=/usr/bin"],
+                    environment: [
+                        "ORCHARD_CONTAINER_DETAIL_REPRODUCTION_ENVIRONMENT_VARIABLE_WITH_A_VERY_LONG_NAME=192.168.64.1/32",
+                        "PATH=/usr/bin",
+                    ],
                     workingDirectory: "/",
                     arguments: ["nginx", "-g", "daemon off;"],
                     executable: "/usr/sbin/nginx",

--- a/Orchard/Services/UITestSupport.swift
+++ b/Orchard/Services/UITestSupport.swift
@@ -30,8 +30,10 @@ struct UITestBackend: ContainerBackend {
                 runtimeHandler: "vm",
                 initProcess: initProcess(
                     terminal: false,
+                    // The long key is deliberate: it is what pushes the value column's
+                    // controls off the row when the key column is unbounded.
                     environment: [
-                        "ORCHARD_CONTAINER_DETAIL_REPRODUCTION_ENVIRONMENT_VARIABLE_WITH_A_VERY_LONG_NAME=192.168.64.1/32",
+                        "ORCHARD_UI_TEST_LONG_ENVIRONMENT_VARIABLE_KEY=192.168.64.1/32",
                         "PATH=/usr/bin",
                     ],
                     workingDirectory: "/",

--- a/Orchard/Views/Features/Containers/ContainerDetail.swift
+++ b/Orchard/Views/Features/Containers/ContainerDetail.swift
@@ -79,16 +79,24 @@ struct ContainerDetailView: View {
                 // Stats master–detail; mounts sit beneath the disk stats.
                 ContainerStatsPanel(container: container)
 
-                // There are only six configuration wells, so eager layout is inexpensive
-                // and avoids SwiftUI's lazy-grid sizing loop with selectable text. Keeping
-                // every well full-width also leaves room for long keys and row controls.
-                VStack(alignment: .leading, spacing: 12) {
-                    sectionWell("Overview") { containerOverviewSection(container: container) }
-                    sectionWell("Environment") { containerEnvironmentSection(container: container) }
-                    sectionWell("Image") { containerImageSection(container: container) }
-                    sectionWell("Process") { containerProcessSection(container: container) }
-                    sectionWell("Network") { containerNetworkSection(container: container) }
-                    sectionWell("Labels") { containerLabelsSection(container: container) }
+                // The rest of the configuration, two per row (paired to balance heights).
+                // These rows are laid out eagerly: inside a LazyVGrid, placing a row whose
+                // wells contain selectable text re-entered the grid's own placement, and
+                // the main thread spun in nested sizeThatFits until the app stopped
+                // responding. Six wells cost nothing to lay out up front.
+                VStack(spacing: 12) {
+                    HStack(alignment: .top, spacing: 12) {
+                        sectionWell("Overview") { containerOverviewSection(container: container) }
+                        sectionWell("Environment") { containerEnvironmentSection(container: container) }
+                    }
+                    HStack(alignment: .top, spacing: 12) {
+                        sectionWell("Image") { containerImageSection(container: container) }
+                        sectionWell("Process") { containerProcessSection(container: container) }
+                    }
+                    HStack(alignment: .top, spacing: 12) {
+                        sectionWell("Network") { containerNetworkSection(container: container) }
+                        sectionWell("Labels") { containerLabelsSection(container: container) }
+                    }
                 }
 
                 Spacer(minLength: 20)
@@ -293,8 +301,11 @@ struct ContainerDetailView: View {
 // MARK: - Environment Variables Table
 
 /// Shared sizing policy for the two key/value tables on the container detail page.
-/// Environment variables and OCI labels commonly contain long, namespaced keys; their
-/// intrinsic widths must not be allowed to consume the whole card.
+/// The column is sized from the longest key, estimated at 7.5 points per character for
+/// the monospaced subheadline the tables draw in, plus padding. Environment variables
+/// and OCI labels routinely carry long namespaced keys, so the estimate is capped:
+/// past the cap the key wraps instead of squeezing the value and its Show/Copy controls
+/// out of the row.
 enum DetailKeyValueTableLayout {
     static let maximumKeyColumnWidth: CGFloat = 160
 
@@ -397,7 +408,7 @@ struct EnvironmentVariablesTable: View {
                             .buttonStyle(.plain)
                             .font(.caption)
                             .foregroundColor(.blue)
-                            .accessibilityIdentifier("environment-value-toggle-\(index)")
+                            .accessibilityIdentifier("environment-value-toggle-\(envPair.key)")
                             Spacer()
                             CopyButton(text: envPair.value, label: "Copy value")
                         }

--- a/Orchard/Views/Features/Containers/ContainerDetail.swift
+++ b/Orchard/Views/Features/Containers/ContainerDetail.swift
@@ -79,12 +79,10 @@ struct ContainerDetailView: View {
                 // Stats master–detail; mounts sit beneath the disk stats.
                 ContainerStatsPanel(container: container)
 
-                // The rest of the configuration, two per row (paired to balance heights).
-                LazyVGrid(
-                    columns: [GridItem(.flexible(), spacing: 12, alignment: .top),
-                              GridItem(.flexible(), alignment: .top)],
-                    spacing: 12
-                ) {
+                // There are only six configuration wells, so eager layout is inexpensive
+                // and avoids SwiftUI's lazy-grid sizing loop with selectable text. Keeping
+                // every well full-width also leaves room for long keys and row controls.
+                VStack(alignment: .leading, spacing: 12) {
                     sectionWell("Overview") { containerOverviewSection(container: container) }
                     sectionWell("Environment") { containerEnvironmentSection(container: container) }
                     sectionWell("Image") { containerImageSection(container: container) }
@@ -294,6 +292,19 @@ struct ContainerDetailView: View {
 
 // MARK: - Environment Variables Table
 
+/// Shared sizing policy for the two key/value tables on the container detail page.
+/// Environment variables and OCI labels commonly contain long, namespaced keys; their
+/// intrinsic widths must not be allowed to consume the whole card.
+enum DetailKeyValueTableLayout {
+    static let maximumKeyColumnWidth: CGFloat = 160
+
+    static func keyColumnWidth(for keys: [String]) -> CGFloat {
+        let longestKey = keys.max { $0.count < $1.count } ?? ""
+        let estimatedWidth = CGFloat(longestKey.count) * 7.5 + 20
+        return min(estimatedWidth, maximumKeyColumnWidth)
+    }
+}
+
 struct EnvironmentVariablesTable: View {
     let environment: [String]
     @State private var revealedValues: Set<Int> = []
@@ -307,12 +318,7 @@ struct EnvironmentVariablesTable: View {
     }
 
     private var maxKeyWidth: CGFloat {
-        let keys = parsedEnvironment.map { $0.key }
-        let maxKey = keys.max { $0.count < $1.count } ?? ""
-
-        // Approximate character width for monospaced font at subheadline size
-        // This is a rough estimation - actual width may vary
-        return CGFloat(maxKey.count) * 7.5 + 20 // 7.5 points per character + padding
+        DetailKeyValueTableLayout.keyColumnWidth(for: parsedEnvironment.map { $0.key })
     }
 
     var body: some View {
@@ -391,6 +397,7 @@ struct EnvironmentVariablesTable: View {
                             .buttonStyle(.plain)
                             .font(.caption)
                             .foregroundColor(.blue)
+                            .accessibilityIdentifier("environment-value-toggle-\(index)")
                             Spacer()
                             CopyButton(text: envPair.value, label: "Copy value")
                         }
@@ -426,11 +433,7 @@ struct LabelsTable: View {
     }
 
     private var maxKeyWidth: CGFloat {
-        let keys = sortedLabels.map { $0.key }
-        let maxKey = keys.max { $0.count < $1.count } ?? ""
-
-        // Approximate character width for monospaced font at subheadline size
-        return CGFloat(maxKey.count) * 7.5 + 20 // 7.5 points per character + padding
+        DetailKeyValueTableLayout.keyColumnWidth(for: sortedLabels.map { $0.key })
     }
 
     var body: some View {

--- a/Orchard/Views/Features/Containers/ContainerDetail.swift
+++ b/Orchard/Views/Features/Containers/ContainerDetail.swift
@@ -49,8 +49,25 @@ struct ContainerDetailView: View {
         .background(Color.accentColor.opacity(0.10), in: RoundedRectangle(cornerRadius: 8))
     }
 
+    private static let wellSpacing: CGFloat = 12
+
+    /// Below this pane width the wells stop pairing up and stack instead. Two wells side
+    /// by side each need roughly 320 points to keep a key/value row intact: measured on
+    /// this page, a 333-point well still fits the key, its value and both controls; at
+    /// 277 points "Show" and "Copy" wrap one letter per line; and by the ~440-point pane
+    /// of a 1024-point window the controls drop out of the row altogether.
+    private static let twoColumnMinimumPaneWidth: CGFloat = 684
+
     // One scrolling page — the former Overview, Environment and Mounts tabs merged.
+    // The geometry reader measures the pane, not the content, so it can't feed its own
+    // height back into layout.
     private var content: some View {
+        GeometryReader { proxy in
+            scrollingContent(twoColumn: proxy.size.width >= Self.twoColumnMinimumPaneWidth)
+        }
+    }
+
+    private func scrollingContent(twoColumn: Bool) -> some View {
         ScrollView {
             VStack(alignment: .leading, spacing: 12) {
                 // Membership banners: a node container belongs to a cluster, a sandbox
@@ -79,22 +96,27 @@ struct ContainerDetailView: View {
                 // Stats master–detail; mounts sit beneath the disk stats.
                 ContainerStatsPanel(container: container)
 
-                // The rest of the configuration, two per row (paired to balance heights).
+                // The rest of the configuration, two per row (paired to balance heights)
+                // while the pane is wide enough for two.
+                //
                 // These rows are laid out eagerly: inside a LazyVGrid, placing a row whose
                 // wells contain selectable text re-entered the grid's own placement, and
                 // the main thread spun in nested sizeThatFits until the app stopped
                 // responding. Six wells cost nothing to lay out up front.
-                VStack(spacing: 12) {
-                    HStack(alignment: .top, spacing: 12) {
+                VStack(spacing: Self.wellSpacing) {
+                    wellRow(twoColumn: twoColumn) {
                         sectionWell("Overview") { containerOverviewSection(container: container) }
+                    } trailing: {
                         sectionWell("Environment") { containerEnvironmentSection(container: container) }
                     }
-                    HStack(alignment: .top, spacing: 12) {
+                    wellRow(twoColumn: twoColumn) {
                         sectionWell("Image") { containerImageSection(container: container) }
+                    } trailing: {
                         sectionWell("Process") { containerProcessSection(container: container) }
                     }
-                    HStack(alignment: .top, spacing: 12) {
+                    wellRow(twoColumn: twoColumn) {
                         sectionWell("Network") { containerNetworkSection(container: container) }
+                    } trailing: {
                         sectionWell("Labels") { containerLabelsSection(container: container) }
                     }
                 }
@@ -106,6 +128,25 @@ struct ContainerDetailView: View {
     }
 
     // MARK: - Detail Sections
+
+    /// A paired row of configuration wells: side by side when the pane can carry two,
+    /// stacked when it can't.
+    @ViewBuilder
+    private func wellRow<Leading: View, Trailing: View>(
+        twoColumn: Bool,
+        @ViewBuilder leading: () -> Leading,
+        @ViewBuilder trailing: () -> Trailing
+    ) -> some View {
+        if twoColumn {
+            HStack(alignment: .top, spacing: Self.wellSpacing) {
+                leading()
+                trailing()
+            }
+        } else {
+            leading()
+            trailing()
+        }
+    }
 
     @ViewBuilder
     private func sectionWell<Content: View>(_ title: String, @ViewBuilder content: () -> Content) -> some View {

--- a/OrchardTests/ContainerDetailLayoutTests.swift
+++ b/OrchardTests/ContainerDetailLayoutTests.swift
@@ -2,17 +2,30 @@ import Foundation
 import Testing
 @testable import Orchard
 
-@Test("Container detail key/value tables preserve room for values")
+/// The key column is sized from the longest key, so an unbounded estimate lets one
+/// namespaced key crowd the value and its Show/Copy controls out of the row.
+@Test("Container detail key/value tables cap the key column for long keys")
 func detailKeyValueTableCapsLongKeys() {
-    let longEnvironmentKey = "ORCHARD_CONTAINER_DETAIL_REPRODUCTION_ENVIRONMENT_VARIABLE_WITH_A_VERY_LONG_NAME"
+    let longKey = "ORCHARD_UI_TEST_LONG_ENVIRONMENT_VARIABLE_KEY"
 
     #expect(
-        DetailKeyValueTableLayout.keyColumnWidth(for: [longEnvironmentKey])
+        DetailKeyValueTableLayout.keyColumnWidth(for: [longKey])
             == DetailKeyValueTableLayout.maximumKeyColumnWidth
     )
 }
 
 @Test("Container detail key/value tables retain natural width for short keys")
 func detailKeyValueTableKeepsShortKeyWidth() {
-    #expect(DetailKeyValueTableLayout.keyColumnWidth(for: ["PATH"]) == 50)
+    let width = DetailKeyValueTableLayout.keyColumnWidth(for: ["PATH"])
+
+    #expect(width < DetailKeyValueTableLayout.maximumKeyColumnWidth)
+    #expect(width > 0)
+}
+
+/// The longest key sets the column, not whichever key happens to come first.
+@Test("Container detail key/value tables size from the longest key")
+func detailKeyValueTableSizesFromLongestKey() {
+    let mixed = DetailKeyValueTableLayout.keyColumnWidth(for: ["PATH", "HOME", "TERM_PROGRAM"])
+
+    #expect(mixed == DetailKeyValueTableLayout.keyColumnWidth(for: ["TERM_PROGRAM"]))
 }

--- a/OrchardTests/ContainerDetailLayoutTests.swift
+++ b/OrchardTests/ContainerDetailLayoutTests.swift
@@ -1,0 +1,18 @@
+import Foundation
+import Testing
+@testable import Orchard
+
+@Test("Container detail key/value tables preserve room for values")
+func detailKeyValueTableCapsLongKeys() {
+    let longEnvironmentKey = "ORCHARD_CONTAINER_DETAIL_REPRODUCTION_ENVIRONMENT_VARIABLE_WITH_A_VERY_LONG_NAME"
+
+    #expect(
+        DetailKeyValueTableLayout.keyColumnWidth(for: [longEnvironmentKey])
+            == DetailKeyValueTableLayout.maximumKeyColumnWidth
+    )
+}
+
+@Test("Container detail key/value tables retain natural width for short keys")
+func detailKeyValueTableKeepsShortKeyWidth() {
+    #expect(DetailKeyValueTableLayout.keyColumnWidth(for: ["PATH"]) == 50)
+}

--- a/OrchardUITests/OrchardUITests.swift
+++ b/OrchardUITests/OrchardUITests.swift
@@ -64,33 +64,42 @@ final class OrchardUITests: XCTestCase {
             app.buttons["Logs"].waitForExistence(timeout: 10),
             "The selected container's detail pane (with its header actions) should render"
         )
+    }
 
-        let detailScrollPoint = app.buttons["Logs"]
-            .coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.5))
-            .withOffset(CGVector(dx: 0, dy: 220))
-        let longEnvironmentValueToggle = app.buttons["environment-value-toggle-0"]
+    /// A long environment key must not push its own row's controls out of the pane: the key
+    /// column is capped, so the key wraps and Show/Copy stay reachable. The seeded container
+    /// carries `ORCHARD_UI_TEST_LONG_ENVIRONMENT_VARIABLE_KEY` for exactly this.
+    @MainActor
+    func testLongEnvironmentKeyKeepsItsRowControlsReachable() throws {
+        let app = launchedApp()
+        openContainersTab(app)
+        XCTAssertTrue(app.staticTexts["uitest-web"].waitForExistence(timeout: 20))
+        XCTAssertTrue(app.buttons["Logs"].waitForExistence(timeout: 10))
 
-        // Scroll from a known point inside the detail pane. Querying the entire SwiftUI
-        // ScrollView asks XCTest to snapshot the full detail hierarchy and can mask the
-        // regression behind a framework timeout. Bounded wheel deltas also avoid waiting
-        // for the inertial animation produced by a synthetic swipe gesture and tolerate
-        // different window sizes and content heights.
-        for _ in 0..<8 {
-            if longEnvironmentValueToggle.exists && longEnvironmentValueToggle.isHittable {
-                break
-            }
-            detailScrollPoint.scroll(byDeltaX: 0, deltaY: -150)
+        // Scroll from a point inside the detail pane rather than querying the SwiftUI
+        // ScrollView: resolving that element asks XCTest to snapshot the whole detail
+        // hierarchy, which is slow enough to time out. Wheel deltas also avoid the inertia
+        // a synthetic swipe adds, and the normalised anchor holds at any window size.
+        let detailPane = app.windows.firstMatch
+            .coordinate(withNormalizedOffset: CGVector(dx: 0.75, dy: 0.6))
+        let toggle = app.buttons["environment-value-toggle-ORCHARD_UI_TEST_LONG_ENVIRONMENT_VARIABLE_KEY"]
+
+        for _ in 0..<8 where !(toggle.exists && toggle.isHittable) {
+            detailPane.scroll(byDeltaX: 0, deltaY: -150)
         }
         XCTAssertTrue(
-            longEnvironmentValueToggle.waitForExistence(timeout: 10),
+            toggle.waitForExistence(timeout: 10),
             "The long environment key's value control should render after scrolling"
         )
         XCTAssertTrue(
-            longEnvironmentValueToggle.isHittable,
+            toggle.isHittable,
             "The value control beside a long environment key should remain onscreen and clickable"
         )
-        longEnvironmentValueToggle.click()
-        XCTAssertEqual(longEnvironmentValueToggle.label, "Hide")
+
+        // The label flips only once SwiftUI has re-rendered the row, so wait for it.
+        toggle.click()
+        let revealed = expectation(for: NSPredicate(format: "label == %@", "Hide"), evaluatedWith: toggle)
+        wait(for: [revealed], timeout: 10)
     }
 
     /// The #54 class: a failed user action must be visible. With the stub set to fail

--- a/OrchardUITests/OrchardUITests.swift
+++ b/OrchardUITests/OrchardUITests.swift
@@ -64,6 +64,33 @@ final class OrchardUITests: XCTestCase {
             app.buttons["Logs"].waitForExistence(timeout: 10),
             "The selected container's detail pane (with its header actions) should render"
         )
+
+        let detailScrollPoint = app.buttons["Logs"]
+            .coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.5))
+            .withOffset(CGVector(dx: 0, dy: 220))
+        let longEnvironmentValueToggle = app.buttons["environment-value-toggle-0"]
+
+        // Scroll from a known point inside the detail pane. Querying the entire SwiftUI
+        // ScrollView asks XCTest to snapshot the full detail hierarchy and can mask the
+        // regression behind a framework timeout. Bounded wheel deltas also avoid waiting
+        // for the inertial animation produced by a synthetic swipe gesture and tolerate
+        // different window sizes and content heights.
+        for _ in 0..<8 {
+            if longEnvironmentValueToggle.exists && longEnvironmentValueToggle.isHittable {
+                break
+            }
+            detailScrollPoint.scroll(byDeltaX: 0, deltaY: -150)
+        }
+        XCTAssertTrue(
+            longEnvironmentValueToggle.waitForExistence(timeout: 10),
+            "The long environment key's value control should render after scrolling"
+        )
+        XCTAssertTrue(
+            longEnvironmentValueToggle.isHittable,
+            "The value control beside a long environment key should remain onscreen and clickable"
+        )
+        longEnvironmentValueToggle.click()
+        XCTAssertEqual(longEnvironmentValueToggle.label, "Hide")
     }
 
     /// The #54 class: a failed user action must be visible. With the stub set to fail


### PR DESCRIPTION
## Description

### User impact

Scrolling through the details of a configuration-heavy container can freeze
Orchard. Once the hang occurs, the window stops responding and memory usage
continues to grow, leaving the user with no practical recovery other than
force-quitting the app.

Long environment-variable and OCI-label keys can also consume most of the
detail pane, pushing their values and Show/Copy controls out of view.

### How to reproduce

1. Start the Apple container system and create a minimal reproduction
   container with intentionally long environment and label keys:

   ```bash
   container system start
   container run --detach \
     --name orchard-scroll-repro \
     --env ORCHARD_CONTAINER_DETAIL_REPRODUCTION_ENVIRONMENT_VARIABLE_WITH_A_VERY_LONG_NAME=192.168.64.1/32 \
     --label com.example.orchard.container-detail.reproduction.with-a-very-long-key=true \
     docker.io/library/alpine:latest sleep 86400
   ```

2. Launch an unpatched Orchard v2.3.0 build, open **Containers**, and select
   `orchard-scroll-repro`.
3. Scroll down through the container's configuration sections. Repeating a
   down/up/down scroll makes the issue especially easy to trigger.

Expected: the detail pane remains responsive and all values and controls stay
inside the pane. Actual: Orchard can stop responding while its memory usage
continues to grow; long keys can also push adjacent controls off-screen.

Clean up the reproduction container when finished:

```bash
container stop orchard-scroll-repro
container delete orchard-scroll-repro
```

### Root cause

The six configuration wells were inside a two-column `LazyVGrid`. Profiling
showed that realizing rows containing selectable SwiftUI text repeatedly
invalidated intrinsic sizes and re-entered lazy-grid placement, creating a
layout feedback loop on the main thread.

Environment and label tables also sized their key column from the longest
key without an upper bound, allowing namespaced keys to crowd out the rest of
the row.

The upstream Orchard v2.3.0 release leaves `ContainerDetail` and its
two-column `LazyVGrid` unchanged, so the latest release does not include this
fix.

### What this PR changes

This replaces the six-item lazy grid with an eager, full-width `VStack`.
There are only six wells, so eager layout is inexpensive and avoids the layout
feedback loop while preserving selectable text.

Environment-variable and OCI-label key columns are capped at 160 points. Long
namespaced keys now wrap instead of pushing values and Show/Copy controls out
of the detail pane.

The UI fixture includes a representative long, namespaced environment key.
The regression scrolls to its value control in bounded increments, verifies
that the control remains hittable, reveals it, and confirms that its label
changes to `Hide`. Unit coverage verifies both capped long-key width and
natural short-key width.

### Screenshots / recording

<img width="1292" height="238" alt="edited-image (2)" src="https://github.com/user-attachments/assets/a07befce-0135-4dd5-94f8-c37acb628f38" />

### Tested on

- Orchard 2.3.3 (`upstream/main` / `v2.3.3`)
- macOS 26.4 (25E246), Apple silicon
- Apple `container` CLI 1.3.0 (release build, commit `d6de569`)
- Full `OrchardTests` target after merging v2.3.3: 322 test definitions
  passed
- Focused container-detail UI regression: passed before merging v2.3.3;
  the post-merge rerun exited while establishing the XCTest runner connection,
  before executing a test assertion
- Full five-test UI scheme: passed before the branch split with the same UI
  patch
- Manual validation with a real container using the same long-key shape:
  repeated down/up/down scrolling stayed responsive; the long key wrapped;
  Show/Copy controls remained visible; revealing the value showed
  `192.168.64.1/32`; Labels rendered at the bottom

### Checklist

- [x] The project builds against Orchard v2.3.3 dependencies
- [x] Unit tests pass (`322 test definitions`)
- [x] The changelog has a scoped container-detail entry